### PR TITLE
Change setVertexBuffers to setVertexBuffer

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -628,11 +628,7 @@ declare global {
     setPipeline(pipeline: GPURenderPipeline): void;
 
     setIndexBuffer(buffer: GPUBuffer, offset?: number): void;
-    setVertexBuffers(
-      startSlot: number,
-      buffers: GPUBuffer[],
-      offsets: number[]
-    ): void;
+    setVertexBuffer(slot: number, buffer: GPUBuffer, offset?: number): void;
 
     draw(
       vertexCount: number,


### PR DESCRIPTION
Following WebGPU spec change at https://github.com/gpuweb/gpuweb/pull/468, this PR updates updates`setVertexBuffers` to `setVertexBuffer`.