### PR TITLE
Replace textureDimension with viewDimension

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,6 +1,7 @@
 // https://github.com/gpuweb/gpuweb/blob/402b69138fbedf4a3c9c85cd1bf7e1cc27c1b34e/spec/index.bs
 // except #280 which removed setSubData
 // except #494 which reverted the addition of GPUAdapter.limits
+// plus #589 which renamed textureDimension to viewDimension
 
 export {};
 

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -238,7 +238,7 @@ declare global {
     binding: number;
     visibility: GPUShaderStageFlags;
     type: GPUBindingType;
-    textureDimension?: GPUTextureViewDimension;
+    viewDimension?: GPUTextureViewDimension;
     textureComponentType?: GPUTextureComponentType;
     multisampled?: boolean;
     hasDynamicOffset?: boolean;


### PR DESCRIPTION
The member for the texture-view-dimension is of type
GPUTextureViewDimension, but the name is textureDimension, which is
confusing because there's also a type GPUTextureDimension[1][2].

[1] gpuweb/gpuweb#587
[2] gpuweb/gpuweb#589