### PR TITLE
Add entry point to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@webgpu/types",
   "version": "0.0.24",
-  "main": "",
+  "main": "src/index.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Hello!

I'm tinkering around with gpuweb/types in a project that uses Rollup where I'm bundling up some Typescript code into a module and importing it into a Javascript module. Due to how Rollup manages dependencies across modules, I found myself having to add webgpu/types to a JS package. However, since the main field is empty, Rollup is unable to process the dependency correctly. This can be fixed by updating the main field in package.json and pointing to an empty JS file.

Thanks!