### PR TITLE
make depthReadOnly/stencilReadOnly optional

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -409,11 +409,11 @@ declare global {
 
     depthLoadValue: GPULoadOp | number;
     depthStoreOp: GPUStoreOp;
-    depthReadOnly: boolean;
+    depthReadOnly?: boolean;
 
     stencilLoadValue: GPULoadOp | number;
     stencilStoreOp: GPUStoreOp;
-    stencilReadOnly: boolean;
+    stencilReadOnly?: boolean;
   }
 
   export interface GPURenderPassDescriptor extends GPUObjectDescriptorBase {


### PR DESCRIPTION
Made a mistake in #21. These should be optional.