### PR TITLE
Added resolveQuerySet to GPUCommandEncoder

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -577,7 +577,8 @@ declare global {
       copySize: GPUExtent3D
     ): void;
     finish(descriptor?: GPUCommandBufferDescriptor): GPUCommandBuffer;
-
+    
+    resolveQuerySet(querySet: GPUQuerySet, firstQuery: number, queryCount: number, destination: GPUBuffer, destinationOffset: number): void;
     writeTimestamp(querySet: GPUQuerySet, queryIndex: number): void;
 
     popDebugGroup(): void;


### PR DESCRIPTION
I think that this is necessary to be able to retrieve information from a GPUQuerySet? I noticed this function was missing when trying to implement benchmarking using the timestamp-query extension. Seems to just work as expected when I added this definition to the types!