### PR TITLE
Add HTMLCanvasElement.getContext("gpupresent")

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -11,6 +11,10 @@ declare global {
     readonly gpu: GPU | undefined;
   }
 
+  export interface HTMLCanvasElement {
+    getContext(contextId: "gpupresent"): GPUCanvasContext | null;
+  }
+
   export interface GPUColorDict {
     a: number;
     b: number;


### PR DESCRIPTION
Without this the context return type needs to be asserted by the client which is less convenient.