### PR TITLE
Add aspect to GPUTextureCopyView

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -317,6 +317,7 @@ declare global {
     texture: GPUTexture;
     mipLevel?: number;
     origin?: GPUOrigin3D;
+    aspect?: GPUTextureAspect;
   }
 
   export interface GPUImageBitmapCopyView {

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -2,7 +2,7 @@
 // except #494 which reverted the addition of GPUAdapter.limits
 // except #591 which removed Uint32Array from GPUShaderModuleDescriptor
 // except removal of old setIndexBuffer signature in #943
-// except #873 which added aspect back to GPUTextureCopyView
+// plus #873 which added aspect back to GPUTextureCopyView
 
 export {};
 

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -2,6 +2,7 @@
 // except #494 which reverted the addition of GPUAdapter.limits
 // except #591 which removed Uint32Array from GPUShaderModuleDescriptor
 // except removal of old setIndexBuffer signature in #943
+// except #873 which added aspect back to GPUTextureCopyView
 
 export {};
 


### PR DESCRIPTION
This patch intends to add the member 'aspect' to GPUTextureCopyView
that follows the latest WebGPU SPEC.