### PR TITLE
Rename OUTPUT_ATTACHMENT -> RENDER_ATTACHMENT, defaultQueue -> queue

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -251,7 +251,7 @@ declare global {
     COPY_DST:          0x02;
     SAMPLED:           0x04;
     STORAGE:           0x08;
-    OUTPUT_ATTACHMENT: 0x10;
+    RENDER_ATTACHMENT: 0x10;
   };
 
   export type GPUMapModeFlags = number;
@@ -585,7 +585,7 @@ declare global {
       copySize: GPUExtent3D
     ): void;
     finish(descriptor?: GPUCommandBufferDescriptor): GPUCommandBuffer;
-    
+
     resolveQuerySet(querySet: GPUQuerySet, firstQuery: number, queryCount: number, destination: GPUBuffer, destinationOffset: number): void;
     writeTimestamp(querySet: GPUQuerySet, queryIndex: number): void;
 
@@ -686,7 +686,7 @@ declare global {
 
     createQuerySet(descriptor: GPUQuerySetDescriptor): GPUQuerySet;
 
-    defaultQueue: GPUQueue;
+    queue: GPUQueue;
 
     pushErrorScope(filter: GPUErrorFilter): void;
     popErrorScope(): Promise<GPUError | null>;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -4,6 +4,8 @@
 // except removal of old setIndexBuffer signature in #943
 // plus #873 which added aspect back to GPUTextureCopyView
 // plus #971 which added stencil8 to GPUTextureFormat
+// plus #1168 which renamed OUTPUT_ATTACHMENT to RENDER_ATTACHMENT
+// plus #1367 which renamed defaultQueue to queue
 
 export {};
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -234,7 +234,7 @@ export const enum TextureUsage {
   CopyDst = 0x02,
   Sampled = 0x04,
   Storage = 0x08,
-  OutputAttachment = 0x10,
+  RenderAttachment = 0x10,
 }
 export const enum MapMode {
   Read = 0x01,


### PR DESCRIPTION
PTAL!

Also, as a general question: Do we have backwards compatibility concerns for these files? For example, should this change leave behind a `defaultQueue` and `OUTPUT_ATTACHEMENT` declaration for some deprecation period?