### PR TITLE
Add missing texture formats: depth16unorm, depth24unorm-stencil8, depth32float-stencil8

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -10,6 +10,8 @@
 // plus #1375 which renamed to GPUImageCopyX (but without removing old names)
 // plus #1390 which renamed depth to depthOrArrayLayers
 // plus #1223 which refactors GPUBindGroupLayout to isolate binding type definitions
+// plus #1024 which added depth24unorm-stencil8 and depth32float-stencil8 to GPUTextureFormat via extensions
+// plus #1026 which added depth16unorm to GPUTextureFormat
 
 export {};
 
@@ -60,7 +62,9 @@ declare global {
     | "texture-compression-bc"
     | "timestamp-query"
     | "pipeline-statistics-query"
-    | "depth-clamping";
+    | "depth-clamping"
+    | "depth24unorm-stencil8"
+    | "depth32float-stencil8";
   export type GPUAddressMode = "clamp-to-edge" | "repeat" | "mirror-repeat";
   /** @deprecated */
   export type GPUBindingType =
@@ -171,10 +175,13 @@ declare global {
     | "rgba32uint"
     | "rgba32sint"
     | "rgba32float"
+    | "depth16unorm"
     | "depth32float"
     | "depth24plus"
     | "depth24plus-stencil8"
     | "stencil8"
+    | "depth24unorm-stencil8"
+    | "depth32float-stencil8"
     | "bc1-rgba-unorm"
     | "bc1-rgba-unorm-srgb"
     | "bc2-rgba-unorm"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,8 @@
 // String enums
 export const enum ExtensionName {
   TextureCompressionBC = 'texture-compression-bc',
+  Depth24UnormStencil8 = 'depth24unorm-stencil8',
+  Depth32FloatStencil8 = 'depth32float-stencil8',
 }
 export const enum AddressMode {
   ClampToEdge = 'clamp-to-edge',
@@ -140,9 +142,11 @@ export const enum TextureFormat {
   RGBA32Uint = 'rgba32uint',
   RGBA32Sint = 'rgba32sint',
   RGBA32Float = 'rgba32float',
+  Depth16Unorm = 'depth16unorm',
   Depth32Float = 'depth32float',
   Depth24Plus = 'depth24plus',
   Depth24PlusStencil8 = 'depth24plus-stencil8',
+  Stencil8 = 'stencil8',
 }
 export const enum TextureComponentType {
   Float = 'float',


### PR DESCRIPTION
PTAL. It looks like that we need to add the missing texture formats into gpuweb/types, in order to add them into gpuweb/cts. 