### PR TITLE
Add occlusionQuerySet in render pass descriptor

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -497,6 +497,7 @@ declare global {
   export interface GPURenderPassDescriptor extends GPUObjectDescriptorBase {
     colorAttachments: Iterable<GPURenderPassColorAttachmentDescriptor>;
     depthStencilAttachment?: GPURenderPassDepthStencilAttachmentDescriptor;
+    occlusionQuerySet?: GPUQuerySet;
   }
 
   export interface GPURenderPipelineDescriptor


### PR DESCRIPTION
For occlusion query, we need to pass query set through render pass descripor.