### PR TITLE
Update to d71d9637eb49bdfb1403ffd7bb8a53fd0ca8cad1

### DIFF
--- a/generated/index.d.ts
+++ b/generated/index.d.ts
@@ -1,7 +1,8 @@
 type GPUBindingResource =
   | GPUSampler
   | GPUTextureView
-  | GPUBufferBinding;
+  | GPUBufferBinding
+  | GPUExternalTexture;
 type GPUBufferDynamicOffset = number;
 type GPUBufferUsageFlags = number;
 type GPUColor =
@@ -25,6 +26,7 @@ type GPUOrigin2D =
 type GPUOrigin3D =
   | Array<GPUIntegerCoordinate>
   | GPUOrigin3DDict;
+type GPUPipelineConstantValue = number;
 type GPUSampleMask = number;
 type GPUShaderStageFlags = number;
 type GPUSignedOffset32 = number;
@@ -113,6 +115,7 @@ type GPUPipelineStatisticName =
 type GPUPowerPreference =
   | "low-power"
   | "high-performance";
+type GPUPredefinedColorSpace = "srgb";
 type GPUPrimitiveTopology =
   | "point-list"
   | "line-list"
@@ -141,7 +144,7 @@ type GPUStorageTextureAccess =
   | "write-only";
 type GPUStoreOp =
   | "store"
-  | "clear";
+  | "discard";
 type GPUTextureAspect =
   | "all"
   | "stencil-only"
@@ -283,25 +286,30 @@ interface GPUBindGroupLayoutEntry {
    */
   visibility: GPUShaderStageFlags;
   /**
-   * When not `undefined` indicates the binding resource type for this {@link GPUBindGroupLayoutEntry}
+   * When not `undefined`, indicates the binding resource type for this {@link GPUBindGroupLayoutEntry}
    * is {@link GPUBufferBinding}.
    */
   buffer?: GPUBufferBindingLayout;
   /**
-   * When not `undefined` indicates the binding resource type for this {@link GPUBindGroupLayoutEntry}
+   * When not `undefined`, indicates the binding resource type for this {@link GPUBindGroupLayoutEntry}
    * is {@link GPUSampler}.
    */
   sampler?: GPUSamplerBindingLayout;
   /**
-   * When not `undefined` indicates the binding resource type for this {@link GPUBindGroupLayoutEntry}
+   * When not `undefined`, indicates the binding resource type for this {@link GPUBindGroupLayoutEntry}
    * is {@link GPUTextureView}.
    */
   texture?: GPUTextureBindingLayout;
   /**
-   * When not `undefined` indicates the binding resource type for this {@link GPUBindGroupLayoutEntry}
+   * When not `undefined`, indicates the binding resource type for this {@link GPUBindGroupLayoutEntry}
    * is {@link GPUTextureView}.
    */
   storageTexture?: GPUStorageTextureBindingLayout;
+  /**
+   * When not `undefined`, indicates the binding resource type for this {@link GPUBindGroupLayoutEntry}
+   * is {@link GPUExternalTexture}.
+   */
+  externalTexture?: GPUExternalTextureBindingLayout;
 }
 
 interface GPUBlendComponent {
@@ -389,19 +397,24 @@ interface GPUDepthStencilState {
 interface GPUDeviceDescriptor
   extends GPUObjectDescriptorBase {
   /**
-   * The set of {@link GPUFeatureName} values in this sequence defines the exact set of
-   * features that must be enabled on the device.
+   * Specifies the features that are required by the device request.
+   * The request will fail if the adapter cannot provide these features.
+   * Exactly the specified set of features, and no more or less, will be allowed in validation
+   * of API calls on the resulting device.
    */
-  nonGuaranteedFeatures?: Array<GPUFeatureName>;
+  requiredFeatures?: Array<GPUFeatureName>;
   /**
-   * Defines the exact limits that must be enabled on the device.
+   * Specifies the limits that are required by the device request.
+   * The request will fail if the adapter cannot provide these limits.
    * Each key must be the name of a member of supported limits.
+   * Exactly the specified limits, and no limit/better or worse,
+   * will be allowed in validation of API calls on the resulting device.
    * <!-- If we ever need limit types other than GPUSize32, we can change the value type to
    * `double` or `any` in the future and write out the type conversion explicitly (by reference
    * to WebIDL spec). Or change the entire type to `any` and add back a `dictionary GPULimits`
    * and define the conversion of the whole object by reference to WebIDL. -->
    */
-  nonGuaranteedLimits?: Record<
+  requiredLimits?: Record<
     string,
     GPUSize32
   >;
@@ -411,6 +424,14 @@ interface GPUExtent3DDict {
   width: GPUIntegerCoordinate;
   height?: GPUIntegerCoordinate;
   depthOrArrayLayers?: GPUIntegerCoordinate;
+}
+
+interface GPUExternalTextureBindingLayout {}
+
+interface GPUExternalTextureDescriptor
+  extends GPUObjectDescriptorBase {
+  source: HTMLVideoElement;
+  colorSpace?: GPUPredefinedColorSpace;
 }
 
 interface GPUFragmentState
@@ -509,6 +530,15 @@ interface GPUPipelineLayoutDescriptor
   bindGroupLayouts: Array<GPUBindGroupLayout>;
 }
 
+interface GPUPresentationConfiguration
+  extends GPUObjectDescriptorBase {
+  device: GPUDevice;
+  format: GPUTextureFormat;
+  usage?: GPUTextureUsageFlags;
+  compositingAlphaMode?: GPUCanvasCompositingAlphaMode;
+  size?: GPUExtent3D;
+}
+
 interface GPUPrimitiveState {
   topology?: GPUPrimitiveTopology;
   stripIndexFormat?: GPUIndexFormat;
@@ -520,6 +550,10 @@ interface GPUPrimitiveState {
 interface GPUProgrammableStage {
   module: GPUShaderModule;
   entryPoint: string;
+  constants?: Record<
+    string,
+    GPUPipelineConstantValue
+  >;
 }
 
 interface GPUQuerySetDescriptor
@@ -656,6 +690,7 @@ interface GPURenderPipelineDescriptor
 
 interface GPURequestAdapterOptions {
   powerPreference?: GPUPowerPreference;
+  forceSoftware?: boolean;
 }
 
 interface GPUSamplerBindingLayout {
@@ -710,14 +745,6 @@ interface GPUStorageTextureBindingLayout {
    * `MTLArgumentBuffer` objects that are more efficient to bind at run-time.
    */
   viewDimension?: GPUTextureViewDimension;
-}
-
-interface GPUSwapChainDescriptor
-  extends GPUObjectDescriptorBase {
-  device: GPUDevice;
-  format: GPUTextureFormat;
-  usage?: GPUTextureUsageFlags;
-  compositingAlphaMode?: GPUCanvasCompositingAlphaMode;
 }
 
 interface GPUTextureBindingLayout {
@@ -998,7 +1025,11 @@ interface GPUAdapter {
   /**
    * The limits in `this`.{@link GPUAdapter#[[adapter]]}.{@link adapter#[[limits]]}.
    */
-  readonly limits: GPUAdapterLimits;
+  readonly limits: GPUSupportedLimits;
+  /**
+   * Returns the value of {@link GPUAdapter#[[adapter]]}.{@link adapter#[[software]]}.
+   */
+  readonly isSoftware: boolean;
   /**
    * Requests a device from the adapter.
    * @param descriptor - Description of the {@link GPUDevice} to request.
@@ -1010,36 +1041,6 @@ interface GPUAdapter {
 
 declare var GPUAdapter: {
   prototype: GPUAdapter;
-};
-
-interface GPUAdapterLimits {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
-  readonly __brand: "GPUAdapterLimits";
-  readonly maxTextureDimension1D: number;
-  readonly maxTextureDimension2D: number;
-  readonly maxTextureDimension3D: number;
-  readonly maxTextureArrayLayers: number;
-  readonly maxBindGroups: number;
-  readonly maxDynamicUniformBuffersPerPipelineLayout: number;
-  readonly maxDynamicStorageBuffersPerPipelineLayout: number;
-  readonly maxSampledTexturesPerShaderStage: number;
-  readonly maxSamplersPerShaderStage: number;
-  readonly maxStorageBuffersPerShaderStage: number;
-  readonly maxStorageTexturesPerShaderStage: number;
-  readonly maxUniformBuffersPerShaderStage: number;
-  readonly maxUniformBufferBindingSize: number;
-  readonly maxStorageBufferBindingSize: number;
-  readonly maxVertexBuffers: number;
-  readonly maxVertexAttributes: number;
-  readonly maxVertexBufferArrayStride: number;
-}
-
-declare var GPUAdapterLimits: {
-  prototype: GPUAdapterLimits;
 };
 
 interface GPUBindGroup
@@ -1145,37 +1146,6 @@ declare var GPUBufferUsage: {
   readonly STORAGE: GPUFlagsConstant;
   readonly INDIRECT: GPUFlagsConstant;
   readonly QUERY_RESOLVE: GPUFlagsConstant;
-};
-
-interface GPUCanvasContext {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
-  readonly __brand: "GPUCanvasContext";
-  /**
-   * Configures the swap chain for this canvas, and returns a new
-   * {@link GPUSwapChain} object representing it. Destroys any swapchain
-   * previously returned by `configureSwapChain`, including all of the
-   * textures it has produced.
-   * @param descriptor - Description of the {@link GPUSwapChain} to configure.
-   */
-  configureSwapChain(
-    descriptor: GPUSwapChainDescriptor
-  ): GPUSwapChain;
-  /**
-   * Returns an optimal {@link GPUTextureFormat} to use for swap chains with this context and the
-   * given device.
-   * @param adapter - Adapter the swap chain format should be queried for.
-   */
-  getSwapChainPreferredFormat(
-    adapter: GPUAdapter
-  ): GPUTextureFormat;
-}
-
-declare var GPUCanvasContext: {
-  prototype: GPUCanvasContext;
 };
 
 interface GPUColorWrite {
@@ -1538,9 +1508,8 @@ interface GPUDevice
   /**
    * Exposes the limits supported by the device
    * (which are exactly the ones with which it was created).
-   * Issue: Should this be an `interface GPUSupportedLimits`?
    */
-  readonly limits: any;
+  readonly limits: GPUSupportedLimits;
   /**
    * The primary {@link GPUQueue} for this device.
    */
@@ -1574,6 +1543,13 @@ interface GPUDevice
   createSampler(
     descriptor?: GPUSamplerDescriptor
   ): GPUSampler;
+  /**
+   * Creates a {@link GPUExternalTexture} wrapping the provided image source.
+   * @param descriptor - Provides the external image source object (and any creation options).
+   */
+  importExternalTexture(
+    descriptor: GPUExternalTextureDescriptor
+  ): GPUExternalTexture;
   /**
    * Creates a {@link GPUBindGroupLayout}.
    * @param descriptor - Description of the {@link GPUBindGroupLayout} to create.
@@ -1619,8 +1595,7 @@ interface GPUDevice
   /**
    * Creates a {@link GPUComputePipeline}. The returned {@link Promise} resolves when the created pipeline
    * is ready to be used without additional delay.
-   * If pipeline creation fails, the returned {@link Promise} resolves to an invalid
-   * {@link GPUComputePipeline} object.
+   * If pipeline creation fails, the returned {@link Promise} rejects with an {@link OperationError}.
    * Note: Use of this method is preferred whenever possible, as it prevents blocking the
    * queue timeline work on pipeline compilation.
    * @param descriptor - Description of the {@link GPUComputePipeline} to create.
@@ -1631,8 +1606,7 @@ interface GPUDevice
   /**
    * Creates a {@link GPURenderPipeline}. The returned {@link Promise} resolves when the created pipeline
    * is ready to be used without additional delay.
-   * If pipeline creation fails, the returned {@link Promise} resolves to an invalid
-   * {@link GPURenderPipeline} object.
+   * If pipeline creation fails, the returned {@link Promise} rejects with an {@link OperationError}.
    * Note: Use of this method is preferred whenever possible, as it prevents blocking the
    * queue timeline work on pipeline compilation.
    * @param descriptor - Description of the {@link GPURenderPipeline} to create.
@@ -1699,6 +1673,20 @@ declare var GPUDeviceLostInfo: {
   prototype: GPUDeviceLostInfo;
 };
 
+interface GPUExternalTexture
+  extends GPUObjectBase {
+  /**
+   * Nominal type branding.
+   * https://github.com/microsoft/TypeScript/pull/33038
+   * @internal
+   */
+  readonly __brand: "GPUExternalTexture";
+}
+
+declare var GPUExternalTexture: {
+  prototype: GPUExternalTexture;
+};
+
 interface GPUMapMode {
   /**
    * Nominal type branding.
@@ -1742,6 +1730,47 @@ interface GPUPipelineLayout
 
 declare var GPUPipelineLayout: {
   prototype: GPUPipelineLayout;
+};
+
+interface GPUPresentationContext {
+  /**
+   * Nominal type branding.
+   * https://github.com/microsoft/TypeScript/pull/33038
+   * @internal
+   */
+  readonly __brand: "GPUPresentationContext";
+  /**
+   * Configures the presentation context for this canvas. Destroys any textures produced with a
+   * previous configuration.
+   * @param configuration - Desired configuration for the presentation context.
+   */
+  configure(
+    configuration: GPUPresentationConfiguration
+  ): undefined;
+  /**
+   * Removes the presentation context configuration. Destroys any textures produced while configured.
+   */
+  unconfigure(): undefined;
+  /**
+   * Returns an optimal {@link GPUTextureFormat} to use with this presentation context and devices
+   * created from the given adapter.
+   * @param adapter - Adapter the format should be queried for.
+   */
+  getPreferredFormat(
+    adapter: GPUAdapter
+  ): GPUTextureFormat;
+  /**
+   * Get the {@link GPUTexture} that will be composited to the document by the {@link GPUPresentationContext}
+   * next.
+   * Note: Developers can expect that the same {@link GPUTexture} object will be returned by every
+   * call to {@link GPUPresentationContext#getCurrentTexture} made within the same frame (i.e. between
+   * invocations of Update the rendering) unless {@link GPUPresentationContext#configure} is called.
+   */
+  getCurrentTexture(): GPUTexture;
+}
+
+declare var GPUPresentationContext: {
+  prototype: GPUPresentationContext;
 };
 
 interface GPUQuerySet
@@ -1816,12 +1845,12 @@ interface GPUQueue
    * Issues a copy operation of the contents of a platform image/canvas
    * into the destination texture.
    * @param source - source image and origin to copy to `destination`.
-   * @param destination - The texture subresource and origin to write to.
+   * @param destination - The texture subresource and origin to write to, and its encoding metadata.
    * @param copySize - Extents of the content to write from `source` to `destination`.
    */
   copyExternalImageToTexture(
     source: GPUImageCopyExternalImage,
-    destination: GPUImageCopyTexture,
+    destination: GPUImageCopyTextureTagged,
     copySize: GPUExtent3D
   ): undefined;
 }
@@ -2045,26 +2074,34 @@ declare var GPUShaderStage: {
 
 type GPUSupportedFeatures = ReadonlySet<string>;
 
-interface GPUSwapChain
-  extends GPUObjectBase {
+interface GPUSupportedLimits {
   /**
    * Nominal type branding.
    * https://github.com/microsoft/TypeScript/pull/33038
    * @internal
    */
-  readonly __brand: "GPUSwapChain";
-  /**
-   * Get the {@link GPUTexture} that will be composited to the document by the {@link GPUCanvasContext}
-   * that created this swap chain next.
-   * Note: Developers can expect that the same {@link GPUTexture} object will be returned by every
-   * call to {@link GPUSwapChain#getCurrentTexture} made within the same frame (i.e. between
-   * invocations of Update the rendering).
-   */
-  getCurrentTexture(): GPUTexture;
+  readonly __brand: "GPUSupportedLimits";
+  readonly maxTextureDimension1D: number;
+  readonly maxTextureDimension2D: number;
+  readonly maxTextureDimension3D: number;
+  readonly maxTextureArrayLayers: number;
+  readonly maxBindGroups: number;
+  readonly maxDynamicUniformBuffersPerPipelineLayout: number;
+  readonly maxDynamicStorageBuffersPerPipelineLayout: number;
+  readonly maxSampledTexturesPerShaderStage: number;
+  readonly maxSamplersPerShaderStage: number;
+  readonly maxStorageBuffersPerShaderStage: number;
+  readonly maxStorageTexturesPerShaderStage: number;
+  readonly maxUniformBuffersPerShaderStage: number;
+  readonly maxUniformBufferBindingSize: number;
+  readonly maxStorageBufferBindingSize: number;
+  readonly maxVertexBuffers: number;
+  readonly maxVertexAttributes: number;
+  readonly maxVertexBufferArrayStride: number;
 }
 
-declare var GPUSwapChain: {
-  prototype: GPUSwapChain;
+declare var GPUSupportedLimits: {
+  prototype: GPUSupportedLimits;
 };
 
 interface GPUTexture


### PR DESCRIPTION
This is my first attempt to update the types to the latest spec.

Primarily for my own personal use but if it benefits I'm happy for any changes to be merged here.

I have removed all references to deprecated features to keep things simple.

If anyone has any feedback, particularly re: the `new()` and `GPUExtent3DStrict` features I would appreciate the advice.