### PR TITLE
Roll gpuweb 7716424b -> 26e16be2b

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.11",
       "license": "Apache-2.0",
       "devDependencies": {
-        "bikeshed-to-ts": "^1.2.0",
+        "bikeshed-to-ts": "github:toji/bikeshed-to-ts",
         "prettier": "^2.2.1"
       }
     },
@@ -51,9 +51,9 @@
       "dev": true
     },
     "node_modules/acorn": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
-      "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -137,14 +137,14 @@
     },
     "node_modules/bikeshed-to-ts": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/bikeshed-to-ts/-/bikeshed-to-ts-1.2.0.tgz",
-      "integrity": "sha512-xFRCIEao/d02ECX1dXEzxy349HDu1CmVzJMobtSgYY3DxiNcmmx7nsmO762vU/HWmS4oZ+knXBDc8kAqXuXaYQ==",
+      "resolved": "git+ssh://git@github.com/toji/bikeshed-to-ts.git#a8f58349cc047646bdfd7311a7c9050a2c802a7a",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@dekkai/data-source": "^0.2.1",
         "typescript": "^4.2.4",
-        "webidl2": "^23.13.1",
-        "webidl2ts": "git+https://github.com/darionco/webidl2ts.git#4df7c2c",
+        "webidl2": "^24.2.0",
+        "webidl2ts": "github:toji/webidl2ts",
         "yargs": "^16.2.0"
       },
       "bin": {
@@ -237,9 +237,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -524,21 +524,21 @@
       "dev": true
     },
     "node_modules/mime-db": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.50.0.tgz",
-      "integrity": "sha512-9tMZCDlYHqeERXEHO9f/hKfNXhre5dK2eE/krIvUjZbS2KPcqGDfNShIWS1uW9XOTKQKqK6qbeOci18rbfW77A==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
+      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
       "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "2.1.33",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.33.tgz",
-      "integrity": "sha512-plLElXp7pRDd0bNZHw+nMd52vRYjLwQjygaNg7ddJ2uJtTlmnTCjWuPKxVu6//AdaRuME84SvLW91sIkBqGT0g==",
+      "version": "2.1.34",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
+      "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
       "dev": true,
       "dependencies": {
-        "mime-db": "1.50.0"
+        "mime-db": "1.51.0"
       },
       "engines": {
         "node": ">= 0.6"
@@ -723,9 +723,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -775,20 +775,20 @@
       }
     },
     "node_modules/webidl2": {
-      "version": "23.13.1",
-      "resolved": "https://registry.npmjs.org/webidl2/-/webidl2-23.13.1.tgz",
-      "integrity": "sha512-u5njf3ZyqPr/4K8D6Cxm3B6MwSgwAdtrzxqHklwKaUdP1aQTmtKN5b65k4wlweJ/pRM6fpKUKYz8RlCJ9tka+w==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/webidl2/-/webidl2-24.2.0.tgz",
+      "integrity": "sha512-Danl5J4EIs3c9uZSd261xY2HxMgy9PSlybdm4f+uuskBuxPelcKGEVlk6HDCw0WTUnaJ6ovx0qOcR5pikAujKQ==",
       "dev": true
     },
     "node_modules/webidl2ts": {
       "version": "1.0.4",
-      "resolved": "git+ssh://git@github.com/darionco/webidl2ts.git#4df7c2c530d848b1be909eece8df9d901ca08963",
+      "resolved": "git+ssh://git@github.com/toji/webidl2ts.git#d6d7e68a0e59e2c716b058ea437f7f49958a0e56",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "jsdom": "^16.4.0",
         "typescript": "^4.2.2",
-        "webidl2": "^23.13.1",
+        "webidl2": "^24.2.0",
         "yargs": "^16.2.0"
       },
       "bin": {
@@ -851,9 +851,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
-      "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
+      "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
       "dev": true,
       "engines": {
         "node": ">=8.3.0"
@@ -956,9 +956,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
-      "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
       "dev": true
     },
     "acorn-globals": {
@@ -1016,15 +1016,14 @@
       "dev": true
     },
     "bikeshed-to-ts": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/bikeshed-to-ts/-/bikeshed-to-ts-1.2.0.tgz",
-      "integrity": "sha512-xFRCIEao/d02ECX1dXEzxy349HDu1CmVzJMobtSgYY3DxiNcmmx7nsmO762vU/HWmS4oZ+knXBDc8kAqXuXaYQ==",
+      "version": "git+ssh://git@github.com/toji/bikeshed-to-ts.git#a8f58349cc047646bdfd7311a7c9050a2c802a7a",
       "dev": true,
+      "from": "bikeshed-to-ts@github:toji/bikeshed-to-ts",
       "requires": {
         "@dekkai/data-source": "^0.2.1",
         "typescript": "^4.2.4",
-        "webidl2": "^23.13.1",
-        "webidl2ts": "git+https://github.com/darionco/webidl2ts.git#4df7c2c",
+        "webidl2": "^24.2.0",
+        "webidl2ts": "github:toji/webidl2ts",
         "yargs": "^16.2.0"
       }
     },
@@ -1104,9 +1103,9 @@
       }
     },
     "debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "dev": true,
       "requires": {
         "ms": "2.1.2"
@@ -1316,18 +1315,18 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.50.0.tgz",
-      "integrity": "sha512-9tMZCDlYHqeERXEHO9f/hKfNXhre5dK2eE/krIvUjZbS2KPcqGDfNShIWS1uW9XOTKQKqK6qbeOci18rbfW77A==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
+      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.33",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.33.tgz",
-      "integrity": "sha512-plLElXp7pRDd0bNZHw+nMd52vRYjLwQjygaNg7ddJ2uJtTlmnTCjWuPKxVu6//AdaRuME84SvLW91sIkBqGT0g==",
+      "version": "2.1.34",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
+      "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
       "dev": true,
       "requires": {
-        "mime-db": "1.50.0"
+        "mime-db": "1.51.0"
       }
     },
     "ms": {
@@ -1470,9 +1469,9 @@
       }
     },
     "typescript": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
     },
     "universalify": {
@@ -1506,19 +1505,19 @@
       "dev": true
     },
     "webidl2": {
-      "version": "23.13.1",
-      "resolved": "https://registry.npmjs.org/webidl2/-/webidl2-23.13.1.tgz",
-      "integrity": "sha512-u5njf3ZyqPr/4K8D6Cxm3B6MwSgwAdtrzxqHklwKaUdP1aQTmtKN5b65k4wlweJ/pRM6fpKUKYz8RlCJ9tka+w==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/webidl2/-/webidl2-24.2.0.tgz",
+      "integrity": "sha512-Danl5J4EIs3c9uZSd261xY2HxMgy9PSlybdm4f+uuskBuxPelcKGEVlk6HDCw0WTUnaJ6ovx0qOcR5pikAujKQ==",
       "dev": true
     },
     "webidl2ts": {
-      "version": "git+ssh://git@github.com/darionco/webidl2ts.git#4df7c2c530d848b1be909eece8df9d901ca08963",
+      "version": "git+ssh://git@github.com/toji/webidl2ts.git#d6d7e68a0e59e2c716b058ea437f7f49958a0e56",
       "dev": true,
-      "from": "webidl2ts@git+https://github.com/darionco/webidl2ts.git#4df7c2c",
+      "from": "webidl2ts@github:toji/webidl2ts",
       "requires": {
         "jsdom": "^16.4.0",
         "typescript": "^4.2.2",
-        "webidl2": "^23.13.1",
+        "webidl2": "^24.2.0",
         "yargs": "^16.2.0"
       }
     },
@@ -1566,9 +1565,9 @@
       }
     },
     "ws": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
-      "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
+      "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "format": "prettier -w dist/index.d.ts"
   },
   "devDependencies": {
-    "bikeshed-to-ts": "^1.2.0",
+    "bikeshed-to-ts": "github:toji/bikeshed-to-ts",
     "prettier": "^2.2.1"
   }
 }


### PR DESCRIPTION
This roll also switches the bikeshed-to-ts dependency to a
personal fork (ideally temporarily) in order to resolve issues
with the use of namespaces in the spec when calling `npm generate`.
This will unblock future rolls.

The generator changes did cause some of the bitflag definitions to
be shuffled to the end of the generated document, so this PR moves
them in order to make future rolls easier.

(I will try to work with the upstream dependencies to get the
necessary bikeshed-to-ts and webidl2ts changes  landed in those
repos, because I have no desire to maintain these libraries on an
ongoing basis.)