### PR TITLE
Add `auto` for implicit pipeline layout

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -733,7 +733,7 @@ interface GPUOrigin3DDict {
 
 interface GPUPipelineDescriptorBase
   extends GPUObjectDescriptorBase {
-  layout?: GPUPipelineLayout;
+  layout?: GPUPipelineLayout | 'auto';
 }
 
 interface GPUPipelineLayoutDescriptor


### PR DESCRIPTION
Regarding recent deprecations, we'll have to specify `auto` as layout instead of `undefined` for an implicit layout. I've left the layout property optional since `undefined` appears to be deprecated for the moment.

Other changes like `dispatch` => `dispatchWorkGroups` seem to already be in here.

![image](https://user-images.githubusercontent.com/23324155/167392413-f2c6ce18-ea46-465e-a52e-00fcc9d6589f.png)
