### PR TITLE
Deprecate compositingAlphaMode => alphaMode

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -563,6 +563,8 @@ interface GPUCanvasConfiguration {
   usage?: GPUTextureUsageFlags;
   viewFormats?: Iterable<GPUTextureFormat>;
   colorSpace?: GPUPredefinedColorSpace;
+  alphaMode?: GPUCanvasCompositingAlphaMode;
+  /** @deprecated Use `alphaMode` instead. */
   compositingAlphaMode?: GPUCanvasCompositingAlphaMode;
   /** @deprecated */
   size?: GPUExtent3D;


### PR DESCRIPTION
`compositingAlphaMode` is recently deprecated in favor of `alphaMode` when configuring context.

![image](https://user-images.githubusercontent.com/23324155/171842675-68a790fe-3d2d-4c23-926e-cfbc76eb20b2.png)
