### PR TITLE
Roll gpuweb a83e999 -> edca800

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -2728,6 +2728,7 @@ interface GPUSupportedLimits {
   readonly maxVertexBufferArrayStride: number;
   readonly maxInterStageShaderComponents: number;
   readonly maxInterStageShaderVariables: number;
+  readonly maxColorAttachments: number;
   readonly maxComputeWorkgroupStorageSize: number;
   readonly maxComputeInvocationsPerWorkgroup: number;
   readonly maxComputeWorkgroupSizeX: number;

--- a/generated/index.d.ts
+++ b/generated/index.d.ts
@@ -2605,6 +2605,7 @@ interface GPUSupportedLimits {
   readonly maxVertexBufferArrayStride: number;
   readonly maxInterStageShaderComponents: number;
   readonly maxInterStageShaderVariables: number;
+  readonly maxColorAttachments: number;
   readonly maxComputeWorkgroupStorageSize: number;
   readonly maxComputeInvocationsPerWorkgroup: number;
   readonly maxComputeWorkgroupSizeX: number;


### PR DESCRIPTION
Small update: Add `maxColorAttachments` to `GPUSupportedLimits`
(So that we can pass test jobs for https://github.com/gpuweb/cts/pull/1520)