### PR TITLE
Fix errors when using with webworker lib

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -20,6 +20,10 @@ interface OffscreenCanvas {
   ): GPUCanvasContext | null;
 }
 
+// Defined as an empty interface here to prevent errors when using these types in a worker.
+interface HTMLVideoElement {
+}
+
 type GPUOrigin2DStrict =
 
     | Iterable<GPUIntegerCoordinate>


### PR DESCRIPTION
Fixes #114.

I'm not sure if this is the preferred way to do this, but I noticed that the reason that HTMLCanvasElement wasn't experiencing similar issues is because it had a partial interface declared elsewhere in the file.