### PR TITLE
Roll gpuweb eb06bb8 -> 4f639ac

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -198,7 +198,6 @@ type GPUFeatureName =
     | "timestamp-query"
     | "indirect-first-instance"
     | "shader-f16"
-    | "bgra8unorm-storage"
     | "rg11b10ufloat-renderable";
 type GPUFilterMode =
 

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -220,6 +220,10 @@ type GPUMipmapFilterMode =
 
     | "nearest"
     | "linear";
+type GPUPipelineErrorReason =
+
+    | "validation"
+    | "internal";
 type GPUPowerPreference =
 
     | "low-power"

--- a/generated/index.d.ts
+++ b/generated/index.d.ts
@@ -140,7 +140,6 @@ type GPUFeatureName =
     | "timestamp-query"
     | "indirect-first-instance"
     | "shader-f16"
-    | "bgra8unorm-storage"
     | "rg11b10ufloat-renderable";
 type GPUFilterMode =
 
@@ -162,6 +161,10 @@ type GPUMipmapFilterMode =
 
     | "nearest"
     | "linear";
+type GPUPipelineErrorReason =
+
+    | "validation"
+    | "internal";
 type GPUPowerPreference =
 
     | "low-power"
@@ -480,12 +483,13 @@ interface GPUBufferBindingLayout {
    */
   hasDynamicOffset?: boolean;
   /**
-   * Indicates the minimum buffer binding size.
+   * Indicates the minimum {@link GPUBufferBinding#size} of a buffer binding used with this bind point.
    * Bindings are always validated against this size in {@link GPUDevice#createBindGroup}.
    * If this *is not* `0`, pipeline creation additionally [$validating shader binding|validates$]
-   * that this value is large enough for the bindings declared in the shader.
-   * If this *is* `0`, draw/dispatch commands additionally [$Validate encoder bind groups|validate$]
-   * that each binding in the {@link GPUBindGroup} is large enough for the bindings declared in the shader.
+   * that this value &ge; the minimum buffer binding size of the variable.
+   * If this *is* `0`, it is ignored by pipeline creation, and instead draw/dispatch commands
+   * [$Validate encoder bind groups|validate$] that each binding in the {@link GPUBindGroup}
+   * satisfies the minimum buffer binding size of the variable.
    * Note:
    * Similar execution-time validation is theoretically possible for other
    * binding-related fields specified for early validation, like
@@ -693,106 +697,6 @@ interface GPUFragmentState
   targets: Array<GPUColorTargetState | null>;
 }
 
-interface GPUImageCopyBuffer
-  extends GPUImageDataLayout {
-  /**
-   * A buffer which either contains image data to be copied or will store the image data being
-   * copied, depending on the method it is being passed to.
-   */
-  buffer: GPUBuffer;
-}
-
-interface GPUImageCopyExternalImage {
-  /**
-   * The source of the image copy. The copy source data is captured at the moment that
-   * {@link GPUQueue#copyExternalImageToTexture} is issued.
-   */
-  source:
-    | ImageBitmap
-    | HTMLVideoElement
-    | HTMLCanvasElement
-    | OffscreenCanvas;
-  /**
-   * Defines the origin of the copy - the minimum (top-left) corner of the source sub-region to copy from.
-   * Together with `copySize`, defines the full copy sub-region.
-   */
-  origin?: GPUOrigin2D;
-  /**
-   * Describes whether the source image is vertically flipped, or not.
-   * If this option is set to `true`, the copy is flipped vertically: the bottom row of the source
-   * region is copied into the first row of the destination region, and so on.
-   * The {@link GPUImageCopyExternalImage#origin} option is still relative to the top-left corner
-   * of the source image, increasing downward.
-   */
-  flipY?: boolean;
-}
-
-interface GPUImageCopyTexture {
-  /**
-   * Texture to copy to/from.
-   */
-  texture: GPUTexture;
-  /**
-   * Mip-map level of the {@link GPUImageCopyTexture#texture} to copy to/from.
-   */
-  mipLevel?: GPUIntegerCoordinate;
-  /**
-   * Defines the origin of the copy - the minimum corner of the texture sub-region to copy to/from.
-   * Together with `copySize`, defines the full copy sub-region.
-   */
-  origin?: GPUOrigin3D;
-  /**
-   * Defines which aspects of the {@link GPUImageCopyTexture#texture} to copy to/from.
-   */
-  aspect?: GPUTextureAspect;
-}
-
-interface GPUImageCopyTextureTagged
-  extends GPUImageCopyTexture {
-  /**
-   * Describes the color space and encoding used to encode data into the destination texture.
-   * This [[#color-space-conversions|may result]] in values outside of the range [0, 1]
-   * being written to the target texture, if its format can represent them.
-   * Otherwise, the results are clamped to the target texture format's range.
-   * Note:
-   * If {@link GPUImageCopyTextureTagged#colorSpace} matches the source image,
-   * conversion may not be necessary. See [[#color-space-conversion-elision]].
-   */
-  colorSpace?: PredefinedColorSpace;
-  /**
-   * Describes whether the data written into the texture should have its RGB channels
-   * premultiplied by the alpha channel, or not.
-   * If this option is set to `true` and the {@link GPUImageCopyExternalImage#source} is also
-   * premultiplied, the source RGB values must be preserved even if they exceed their
-   * corresponding alpha values.
-   * Note:
-   * If {@link GPUImageCopyTextureTagged#premultipliedAlpha} matches the source image,
-   * conversion may not be necessary. See [[#color-space-conversion-elision]].
-   */
-  premultipliedAlpha?: boolean;
-}
-
-interface GPUImageDataLayout {
-  /**
-   * The offset, in bytes, from the beginning of the image data source (such as a
-   * {@link GPUImageCopyBuffer#buffer|GPUImageCopyBuffer.buffer}) to the start of the image data
-   * within that source.
-   */
-  offset?: GPUSize64;
-  /**
-   * The stride, in bytes, between the beginning of each block row and the subsequent block row.
-   * Required if there are multiple block rows (i.e. the copy height or depth is more than one block).
-   */
-  bytesPerRow?: GPUSize32;
-  /**
-   * Number of block rows per single image of the texture.
-   * {@link GPUImageDataLayout#rowsPerImage} &times;
-   * {@link GPUImageDataLayout#bytesPerRow} is the stride, in bytes, between the beginning of each image of data and the subsequent image.
-   * Required if there are multiple images (i.e. the copy depth is more than one).
-   */
-  rowsPerImage?: GPUSize32;
-}
-
 interface GPUMultisampleState {
   /**
    * Number of samples per pixel. This {@link GPURenderPipeline} will be compatible only
@@ -837,6 +741,10 @@ interface GPUPipelineDescriptorBase
     | GPUAutoLayoutMode;
 }
 
+interface GPUPipelineErrorInit {
+  reason: GPUPipelineErrorReason;
+}
+
 interface GPUPipelineLayoutDescriptor
   extends GPUObjectDescriptorBase {
   /**
@@ -876,7 +784,7 @@ interface GPUPrimitiveState {
    */
   cullMode?: GPUCullMode;
   /**
-   * If true, indicates that depth clipping is disabled. See [[#depth-clip-control]] for additional details.
+   * If true, indicates that depth clipping is disabled.
    * Requires the {@link GPUFeatureName#"depth-clip-control"} feature to be enabled.
    */
   unclippedDepth?: boolean;
@@ -958,7 +866,7 @@ interface GPURenderPassDepthStencilAttachment {
    * Indicates the value to clear {@link GPURenderPassDepthStencilAttachment#view}'s depth component
    * to prior to executing the render pass. Ignored if {@link GPURenderPassDepthStencilAttachment#depthLoadOp}
    * is not {@link GPULoadOp#"clear"}. Must be between 0.0 and 1.0, inclusive.
-   * <!-- unless unrestricted depth is enabled -->
+   * <!-- POSTV1(unrestricted-depth): unless unrestricted depth is enabled -->
    */
   depthClearValue?: number;
   /**
@@ -970,7 +878,6 @@ interface GPURenderPassDepthStencilAttachment {
   /**
    * The store operation to perform on {@link GPURenderPassDepthStencilAttachment#view}'s
    * depth component after executing the render pass.
-   * Note: It is recommended to prefer a clear-value; see {@link GPULoadOp#"load"}.
    */
   depthStoreOp?: GPUStoreOp;
   /**
@@ -1373,32 +1280,12 @@ interface GPUVertexState
 interface GPUBindingCommandsMixin {
   /**
    * Sets the current {@link GPUBindGroup} for the given index.
-   * @param index - The index to set the bind group at.
-   * @param bindGroup - Bind group to use for subsequent render or compute commands.
-   * 	<!--The overload appears to be confusing bikeshed, and it ends up expecting this to
-   * 	define the arguments for the 5-arg variant of the method, despite the "for"
-   * 	explicitly pointing at the 3-arg variant. See
-   * @param https - //github.com/plinss/widlparser/issues/56 and
-   * @param https - //github.com/tabatkins/bikeshed/issues/1740 -->
-   * @param dynamicOffsets - Array containing buffer offsets in bytes for each entry in
-   * 	`bindGroup` marked as {@link GPUBindGroupLayoutEntry#buffer}.{@link GPUBufferBindingLayout#hasDynamicOffset}.-->
    */
   setBindGroup(
     index: GPUIndex32,
     bindGroup: GPUBindGroup,
     dynamicOffsets?: Array<GPUBufferDynamicOffset>
   ): undefined;
-  /**
-   * Sets the current {@link GPUBindGroup} for the given index, specifying dynamic offsets as a subset
-   * of a {@link Uint32Array}.
-   * @param index - The index to set the bind group at.
-   * @param bindGroup - Bind group to use for subsequent render or compute commands.
-   * @param dynamicOffsetsData - Array containing buffer offsets in bytes for each entry in
-   * 	`bindGroup` marked as {@link GPUBindGroupLayoutEntry#buffer}.{@link GPUBufferBindingLayout#hasDynamicOffset}.
-   * @param dynamicOffsetsDataStart - Offset in elements into `dynamicOffsetsData` where the
-   * 	buffer offset data begins.
-   * @param dynamicOffsetsDataLength - Number of buffer offsets to read from `dynamicOffsetsData`.
-   */
   setBindGroup(
     index: GPUIndex32,
     bindGroup: GPUBindGroup,
@@ -1923,23 +1810,29 @@ interface GPUCompilationMessage {
    */
   readonly __brand: "GPUCompilationMessage";
   /**
-   * A human-readable string containing the message generated during the shader compilation.
+   * The human-readable, localizable text for this compilation message.
+   * Note: The {@link GPUCompilationMessage#message} should follow the best practices for language
+   * and direction information. This includes making use of any future standards which may
+   * emerge regarding the reporting of string language and direction metadata.
+   * <p class="note editorial">Editorial:
+   * At the time of this writing, no language/direction recommendation is available that provides
+   * compatibility and consistency with legacy APIs, but when there is, adopt it formally.
    */
   readonly message: string;
   /**
    * The severity level of the message.
-   * If the {@link GPUCompilationMessage#type} is "error", it corresponds to a
-   * shader-creation error.
+   * If the {@link GPUCompilationMessage#type} is {@link GPUCompilationMessageType#"error"}, it
+   * corresponds to a shader-creation error.
    */
   readonly type: GPUCompilationMessageType;
   /**
    * The line number in the shader {@link GPUShaderModuleDescriptor#code} the
    * {@link GPUCompilationMessage#message} corresponds to. Value is one-based, such that a lineNum of
-   * `1` indicates the first line of the shader {@link GPUShaderModuleDescriptor#code}.
+   * `1` indicates the first line of the shader {@link GPUShaderModuleDescriptor#code}. Lines are
+   * delimited by line breaks.
    * If the {@link GPUCompilationMessage#message} corresponds to a substring this points to
    * the line on which the substring begins. Must be `0` if the {@link GPUCompilationMessage#message}
    * does not correspond to any specific point in the shader {@link GPUShaderModuleDescriptor#code}.
-   * Issue(gpuweb/gpuweb#2435): Reference WGSL spec when it [defines what a line is](https://gpuweb.github.io/gpuweb/wgsl/#comments).
    */
   readonly lineNum: number;
   /**
@@ -2127,23 +2020,24 @@ interface GPUDevice
     descriptor: GPUShaderModuleDescriptor
   ): GPUShaderModule;
   /**
-   * Creates a {@link GPUComputePipeline}.
+   * Creates a {@link GPUComputePipeline} using immediate pipeline creation.
    * @param descriptor - Description of the {@link GPUComputePipeline} to create.
    */
   createComputePipeline(
     descriptor: GPUComputePipelineDescriptor
   ): GPUComputePipeline;
   /**
-   * Creates a {@link GPURenderPipeline}.
+   * Creates a {@link GPURenderPipeline} using immediate pipeline creation.
    * @param descriptor - Description of the {@link GPURenderPipeline} to create.
    */
   createRenderPipeline(
     descriptor: GPURenderPipelineDescriptor
   ): GPURenderPipeline;
   /**
-   * Creates a {@link GPUComputePipeline}. The returned {@link Promise} resolves when the created pipeline
+   * Creates a {@link GPUComputePipeline} using async pipeline creation.
+   * The returned {@link Promise} resolves when the created pipeline
    * is ready to be used without additional delay.
-   * If pipeline creation fails, the returned {@link Promise} rejects with an {@link OperationError}.
+   * If pipeline creation fails, the returned {@link Promise} rejects with an {@link GPUPipelineError}.
    * Note: Use of this method is preferred whenever possible, as it prevents blocking the
    * queue timeline work on pipeline compilation.
    * @param descriptor - Description of the {@link GPUComputePipeline} to create.
@@ -2152,9 +2046,10 @@ interface GPUDevice
     descriptor: GPUComputePipelineDescriptor
   ): Promise<GPUComputePipeline>;
   /**
-   * Creates a {@link GPURenderPipeline}. The returned {@link Promise} resolves when the created pipeline
+   * Creates a {@link GPURenderPipeline} using async pipeline creation.
+   * The returned {@link Promise} resolves when the created pipeline
    * is ready to be used without additional delay.
-   * If pipeline creation fails, the returned {@link Promise} rejects with an {@link OperationError}.
+   * If pipeline creation fails, the returned {@link Promise} rejects with an {@link GPUPipelineError}.
    * Note: Use of this method is preferred whenever possible, as it prevents blocking the
    * queue timeline work on pipeline compilation.
    * @param descriptor - Description of the {@link GPURenderPipeline} to create.
@@ -2231,12 +2126,19 @@ declare var GPUDeviceLostInfo: {
 
 interface GPUError {
   /**
-   * A human-readable message providing information about the error that occurred.
+   * A human-readable, localizable text message providing information about the error that
+   * occurred.
    * Note: This message is generally intended for application developers to debug their
    * applications and capture information for debug reports, not to be surfaced to end-users.
    * Note: User agents should not include potentially machine-parsable details in this message,
    * such as free system memory on {@link GPUErrorFilter#"out-of-memory"} or other details about the
    * conditions under which memory was exhausted.
+   * Note: The {@link GPUError#message} should follow the best practices for language and
+   * direction information. This includes making use of any future standards which may emerge
+   * regarding the reporting of string language and direction metadata.
+   * <p class="note editorial">Editorial:
+   * At the time of this writing, no language/direction recommendation is available that provides
+   * compatibility and consistency with legacy APIs, but when there is, adopt it formally.
    */
   readonly message: string;
 }
@@ -2298,6 +2200,33 @@ declare var GPUOutOfMemoryError: {
   );
 };
 
+interface GPUPipelineError
+  extends DOMException {
+  /**
+   * Nominal type branding.
+   * https://github.com/microsoft/TypeScript/pull/33038
+   * @internal
+   */
+  readonly __brand: "GPUPipelineError";
+  /**
+   * A read-only slot-backed attribute exposing the type of error encountered in pipeline creation
+   * as a <dfn enum for=>GPUPipelineErrorReason</dfn>:
+   * <ul dfn-type=enum-value dfn-for=GPUPipelineErrorReason>
+   * - <dfn>"validation"</dfn>: A [$validation error$].
+   * - <dfn>"internal"</dfn>: An [$internal error$].
+   * </ul>
+   */
+  readonly reason: GPUPipelineErrorReason;
+}
+
+declare var GPUPipelineError: {
+  prototype: GPUPipelineError;
+  new (
+    message: string,
+    options: GPUPipelineErrorInit
+  );
+};
+
 interface GPUPipelineLayout
   extends GPUObjectBase {
   /**
@@ -2354,13 +2283,6 @@ interface GPUQueue
   submit(
     commandBuffers: Array<GPUCommandBuffer>
   ): undefined;
-  /**
-   * Returns a {@link Promise} that resolves once this queue finishes processing all the work submitted
-   * up to this moment.
-   * Resolution of this {@link Promise} implies the completion of
-   * {@link GPUBuffer#mapAsync} calls made prior to that call,
-   * on {@link GPUBuffer}s last used exclusively on that queue.
-   */
   onSubmittedWorkDone(): Promise<undefined>;
   /**
    * Issues a write operation of the provided data into a {@link GPUBuffer}.
@@ -2401,7 +2323,7 @@ interface GPUQueue
    * values, as copying into the corresponding non-`-srgb` format.
    * Thus, after a copy operation, sampling the destination texture has
    * different results depending on whether its format is `-srgb`, all else unchanged.
-   * Issue: If an srgb-linear color space is added, explain here how it interacts.
+   * <!-- POSTV1(srgb-linear): If added, explain here how it interacts. -->
    * @param source - source image and origin to copy to `destination`.
    * @param destination - The texture subresource and origin to write to, and its encoding metadata.
    * @param copySize - Extents of the content to write from `source` to `destination`.
@@ -2510,7 +2432,7 @@ interface GPURenderPassEncoder
     color: GPUColor
   ): undefined;
   /**
-   * Sets the {@link GPURenderPassEncoder#[[stencil_reference]]} value used during stencil tests with
+   * Sets the {@link RenderState#[[stencilReference]]} value used during stencil tests with
    * the {@link GPUStencilOperation#"replace"} {@link GPUStencilOperation}.
    * @param reference - The new stencil reference value.
    */
@@ -2633,7 +2555,7 @@ interface GPUSupportedLimits {
   readonly maxInterStageShaderComponents: number;
   readonly maxInterStageShaderVariables: number;
   readonly maxColorAttachments: number;
-  readonly maxColorAttachmentBytesPerPixel: number;
+  readonly maxColorAttachmentBytesPerSample: number;
   readonly maxComputeWorkgroupStorageSize: number;
   readonly maxComputeInvocationsPerWorkgroup: number;
   readonly maxComputeWorkgroupSizeX: number;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@webgpu/types",
       "version": "0.1.24",
       "license": "BSD-3-Clause",
+      "dependencies": {
+        "typescript": "^4.6.4"
+      },
       "devDependencies": {
         "bikeshed-to-ts": "github:toji/bikeshed-to-ts",
         "prettier": "^2.2.1",
@@ -807,10 +810,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
-      "dev": true,
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1630,10 +1632,9 @@
       }
     },
     "typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
-      "dev": true
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg=="
     },
     "universalify": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
     "bikeshed-to-ts": "github:toji/bikeshed-to-ts",
     "prettier": "^2.2.1",
     "typedoc": "^0.23.22"
+  },
+  "dependencies": {
+    "typescript": "^4.6.4"
   }
 }


### PR DESCRIPTION
Also rolls back typescript version back because of this [issue](https://stackoverflow.com/questions/73573397/when-running-npm-install-legacy-peer-deps-got-error-debug-failure-unhandled).