### PR TITLE
move typescript to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,11 @@
       "name": "@webgpu/types",
       "version": "0.1.25",
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "typescript": "^4.6.4"
-      },
       "devDependencies": {
         "bikeshed-to-ts": "github:toji/bikeshed-to-ts",
         "prettier": "^2.2.1",
-        "typedoc": "^0.23.22"
+        "typedoc": "^0.23.22",
+        "typescript": "4.6.4"
       }
     },
     "node_modules/@dekkai/data-source": {
@@ -813,6 +811,7 @@
       "version": "4.6.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
       "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1634,7 +1633,8 @@
     "typescript": {
       "version": "4.6.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg=="
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "dev": true
     },
     "universalify": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -19,9 +19,7 @@
   "devDependencies": {
     "bikeshed-to-ts": "github:toji/bikeshed-to-ts",
     "prettier": "^2.2.1",
-    "typedoc": "^0.23.22"
-  },
-  "dependencies": {
-    "typescript": "^4.6.4"
+    "typedoc": "^0.23.22",
+    "typescript": "4.6.4"
   }
 }


### PR DESCRIPTION
I'm assuming it wasn't intentional to make every downstream project install typescript