### PR TITLE
Roll gpuweb 4f639ac -> 6d23273 and rename to getCompilationInfo

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -2773,7 +2773,7 @@ interface GPUShaderModule
    * The locations, order, and contents of messages are implementation-defined.
    * In particular, messages may not be ordered by {@link GPUCompilationMessage#lineNum}.
    */
-  compilationInfo(): Promise<GPUCompilationInfo>;
+  getCompilationInfo(): Promise<GPUCompilationInfo>;
 }
 
 declare var GPUShaderModule: {

--- a/generated/index.d.ts
+++ b/generated/index.d.ts
@@ -2510,7 +2510,7 @@ interface GPUShaderModule
    * The locations, order, and contents of messages are implementation-defined.
    * In particular, messages may not be ordered by {@link GPUCompilationMessage#lineNum}.
    */
-  compilationInfo(): Promise<GPUCompilationInfo>;
+  getCompilationInfo(): Promise<GPUCompilationInfo>;
 }
 
 declare var GPUShaderModule: {


### PR DESCRIPTION
* Updated gpuweb 4f639ac -> 6d23273
* Match the latest spec
  * Rename GPUShaderModule.compilationInfo to GPUShaderModule.getCompilationInfo

To reflect https://github.com/gpuweb/gpuweb/pull/3857
Needed for https://github.com/gpuweb/cts/pull/2291