### PR TITLE
Add tests for build on various TypeScript versions

### DIFF
--- a/.github/workflows/deploy-to-gh-pages.yml
+++ b/.github/workflows/deploy-to-gh-pages.yml
@@ -21,6 +21,7 @@ jobs:
           node-version: '16.x'
 
       - run: npm ci
+      - run: npm test
       - run: npm run build-docs
 
       - name: Deploy 📦

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ See the [TypeScript handbook](http://www.typescriptlang.org/docs/handbook/declar
 - npm: `npm install --save @webgpu/types`
 - yarn: `yarn add @webgpu/types`
 
+If you are on TypeScript < 5.1, you will also need to install `@types/dom-webcodecs`
+as a sibling dependency. The version you need depends on the TypeScript version;
+see the [tests](tests/) for examples.
+
 ### Configure
 
 #### TypeScript `tsc` and `tsc`-based bundlers

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dist/**/*"
   ],
   "scripts": {
-    "test": "for t in tests/* ; do (cd \"$t\" && npm i && npm test); done",
+    "test": "for t in tests/*/ ; do (cd \"$t\" && npm i && npm test); done",
     "build-docs": "cd tsdoc-src && npm ci && npm run build",
     "generate": "bikeshed-to-ts --in ./gpuweb/spec/index.bs --out ./generated/index.d.ts --forceGlobal --nominal && prettier -w generated/index.d.ts",
     "format": "prettier -w dist/index.d.ts"

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,1 @@
+package-lock.json

--- a/tests/ts4.6/index.ts
+++ b/tests/ts4.6/index.ts
@@ -1,0 +1,1 @@
+/// <reference types="@webgpu/types" />

--- a/tests/ts4.6/package.json
+++ b/tests/ts4.6/package.json
@@ -1,0 +1,10 @@
+{
+  "scripts": {
+    "test": "tsc --version && tsc"
+  },
+  "dependencies": {
+    "@webgpu/types": "file:../..",
+    "@types/dom-webcodecs": "0.1.3",
+    "typescript": "~4.6.0"
+  }
+}

--- a/tests/ts4.6/tsconfig.json
+++ b/tests/ts4.6/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["index.ts"]
+}

--- a/tests/ts4.7/index.ts
+++ b/tests/ts4.7/index.ts
@@ -1,0 +1,1 @@
+/// <reference types="@webgpu/types" />

--- a/tests/ts4.7/package.json
+++ b/tests/ts4.7/package.json
@@ -1,0 +1,10 @@
+{
+  "scripts": {
+    "test": "tsc --version && tsc"
+  },
+  "dependencies": {
+    "@webgpu/types": "file:../..",
+    "@types/dom-webcodecs": "0.1.4",
+    "typescript": "~4.7.0"
+  }
+}

--- a/tests/ts4.7/tsconfig.json
+++ b/tests/ts4.7/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["index.ts"]
+}

--- a/tests/ts4.9/index.ts
+++ b/tests/ts4.9/index.ts
@@ -1,0 +1,1 @@
+/// <reference types="@webgpu/types" />

--- a/tests/ts4.9/package.json
+++ b/tests/ts4.9/package.json
@@ -1,0 +1,10 @@
+{
+  "scripts": {
+    "test": "tsc --version && tsc"
+  },
+  "dependencies": {
+    "@webgpu/types": "file:../..",
+    "@types/dom-webcodecs": "0.1.5",
+    "typescript": "~4.9.0"
+  }
+}

--- a/tests/ts4.9/tsconfig.json
+++ b/tests/ts4.9/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["index.ts"]
+}

--- a/tests/ts5.1/index.ts
+++ b/tests/ts5.1/index.ts
@@ -1,0 +1,1 @@
+/// <reference types="@webgpu/types" />

--- a/tests/ts5.1/package.json
+++ b/tests/ts5.1/package.json
@@ -1,0 +1,9 @@
+{
+  "scripts": {
+    "test": "tsc --version && tsc"
+  },
+  "dependencies": {
+    "@webgpu/types": "file:../..",
+    "typescript": "~5.1.0"
+  }
+}

--- a/tests/ts5.1/tsconfig.json
+++ b/tests/ts5.1/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["index.ts"]
+}

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "lib": ["DOM", "ESNext"],
+    "module": "ESNext",
+    "noEmit": true,
+    "strict": true,
+    "target": "ESNext"
+  }
+}


### PR DESCRIPTION
These also serve as examples of how to use these types with different TypeScript versions.

Also remove some comments from upstream that cause compilation issues in tsdoc.

Closes #127