### PR TITLE
Run tsdoc on PRs, move build to a subdir, fix warnings

### DIFF
--- a/.github/workflows/deploy-to-gh-pages.yml
+++ b/.github/workflows/deploy-to-gh-pages.yml
@@ -1,5 +1,8 @@
 name: Build and Deploy
 on:
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main
@@ -17,14 +20,13 @@ jobs:
         with:
           node-version: '16.x'
 
-      - name: Install and Build 🏭
-        run: |
-          npm ci
-          npm run build-ci
+      - run: npm ci
+      - run: npm run build-docs
 
       - name: Deploy 📦
+        if: ${{ success() && github.ref == 'refs/heads/main' }}
         uses: JamesIves/github-pages-deploy-action@3.6.2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages
-          FOLDER: out
+          FOLDER: tsdoc-src/out

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /dist/
-/node_modules/
 /out/
 /generated/webgpu.ts
+node_modules
 .DS_Store

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1066,48 +1066,6 @@ interface GPUProgrammableStage {
    * Values are specified as <dfn typedef for="">GPUPipelineConstantValue</dfn>, which is a {@link double}.
    * They are converted [$to WGSL type$] of the pipeline-overridable constant (`bool`/`i32`/`u32`/`f32`/`f16`).
    * If conversion fails, a validation error is generated.
-   * <div class=example>
-   * Pipeline-overridable constants defined in WGSL:
-   * <pre highlight=wgsl>
-   * @id(0)      override has_point_light: bool = true;  // Algorithmic control.
-   * @id(1200)   override specular_param: f32 = 2.3;     // Numeric control.
-   * @id(1300)   override gain: f32;                     // Must be overridden.
-   * override width: f32 = 0.0;              // Specifed at the API level
-   * //   using the name "width".
-   * override depth: f32;                    // Specifed at the API level
-   * //   using the name "depth".
-   * //   Must be overridden.
-   * override height = 2 * depth;            // The default value
-   * // (if not set at the API level),
-   * // depends on another
-   * // overridable constant.
-   * </pre>
-   * Corresponding JavaScript code, providing only the overrides which are required
-   * (have no defaults):
-   * <pre highlight=js>
-   * {
-   * // ...
-   * constants: {
-   * 1300: 2.0,  // "gain"
-   * depth: -1,  // "depth"
-   * }
-   * }
-   * </pre>
-   * Corresponding JavaScript code, overriding all constants:
-   * <pre highlight=js>
-   * {
-   * // ...
-   * constants: {
-   * 0: false,   // "has_point_light"
-   * 1200: 3.0,  // "specular_param"
-   * 1300: 2.0,  // "gain"
-   * width: 20,  // "width"
-   * depth: -1,  // "depth"
-   * height: 15, // "height"
-   * }
-   * }
-   * </pre>
-   * </div>
    */
   constants?: Record<
     string,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,7 @@
       "license": "BSD-3-Clause",
       "devDependencies": {
         "bikeshed-to-ts": "github:toji/bikeshed-to-ts",
-        "prettier": "^2.2.1",
-        "typedoc": "^0.23.22",
-        "typescript": "4.6.4"
+        "prettier": "^2.2.1"
       }
     },
     "node_modules/@dekkai/data-source": {
@@ -137,12 +135,6 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
-    },
     "node_modules/bikeshed-to-ts": {
       "version": "1.2.0",
       "resolved": "git+ssh://git@github.com/toji/bikeshed-to-ts.git#a8f58349cc047646bdfd7311a7c9050a2c802a7a",
@@ -157,15 +149,6 @@
       },
       "bin": {
         "bikeshed-to-ts": "src/cli.js"
-      }
-    },
-    "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/browser-process-hrtime": {
@@ -521,12 +504,6 @@
         }
       }
     },
-    "node_modules/jsonc-parser": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
-      "dev": true
-    },
     "node_modules/levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -545,24 +522,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
-    },
-    "node_modules/lunr": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
-      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
-      "dev": true
-    },
-    "node_modules/marked": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.4.tgz",
-      "integrity": "sha512-Wcc9ikX7Q5E4BYDPvh1C6QNSxrjC9tBgz+A/vAhp59KXUgachw++uMvMKiSW8oA85nopmPZcEvBoex/YLMsiyA==",
-      "dev": true,
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
     },
     "node_modules/mime-db": {
       "version": "1.51.0",
@@ -583,18 +542,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/minimatch": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
-      "integrity": "sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/ms": {
@@ -695,17 +642,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/shiki": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.11.1.tgz",
-      "integrity": "sha512-EugY9VASFuDqOexOgXR18ZV+TbFrQHeCpEYaXamO+SZlsnT/2LxuLBX25GGtIrwaEVFXUAbUQ601SWE2rMwWHA==",
-      "dev": true,
-      "dependencies": {
-        "jsonc-parser": "^3.0.0",
-        "vscode-oniguruma": "^1.6.1",
-        "vscode-textmate": "^6.0.0"
-      }
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -786,27 +722,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/typedoc": {
-      "version": "0.23.22",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.22.tgz",
-      "integrity": "sha512-5sJkjK60xp8A7YpcYniu3+Wf0QcgojEnhzHuCN+CkdpQkKRhOspon/9+sGTkGI8kjVkZs3KHrhltpQyVhRMVfw==",
-      "dev": true,
-      "dependencies": {
-        "lunr": "^2.3.9",
-        "marked": "^4.0.19",
-        "minimatch": "^5.1.0",
-        "shiki": "^0.11.1"
-      },
-      "bin": {
-        "typedoc": "bin/typedoc"
-      },
-      "engines": {
-        "node": ">= 14.14"
-      },
-      "peerDependencies": {
-        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x"
-      }
-    },
     "node_modules/typescript": {
       "version": "4.6.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
@@ -828,18 +743,6 @@
       "engines": {
         "node": ">= 4.0.0"
       }
-    },
-    "node_modules/vscode-oniguruma": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
-      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
-      "dev": true
-    },
-    "node_modules/vscode-textmate": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-6.0.0.tgz",
-      "integrity": "sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==",
-      "dev": true
     },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
@@ -1112,12 +1015,6 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
-    "balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
-    },
     "bikeshed-to-ts": {
       "version": "git+ssh://git@github.com/toji/bikeshed-to-ts.git#a8f58349cc047646bdfd7311a7c9050a2c802a7a",
       "dev": true,
@@ -1128,15 +1025,6 @@
         "webidl2": "^24.2.0",
         "webidl2ts": "github:toji/webidl2ts",
         "yargs": "^16.2.0"
-      }
-    },
-    "brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "requires": {
-        "balanced-match": "^1.0.0"
       }
     },
     "browser-process-hrtime": {
@@ -1410,12 +1298,6 @@
         "xml-name-validator": "^3.0.0"
       }
     },
-    "jsonc-parser": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
-      "dev": true
-    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -1432,18 +1314,6 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
-    "lunr": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
-      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
-      "dev": true
-    },
-    "marked": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.4.tgz",
-      "integrity": "sha512-Wcc9ikX7Q5E4BYDPvh1C6QNSxrjC9tBgz+A/vAhp59KXUgachw++uMvMKiSW8oA85nopmPZcEvBoex/YLMsiyA==",
-      "dev": true
-    },
     "mime-db": {
       "version": "1.51.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
@@ -1457,15 +1327,6 @@
       "dev": true,
       "requires": {
         "mime-db": "1.51.0"
-      }
-    },
-    "minimatch": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
-      "integrity": "sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==",
-      "dev": true,
-      "requires": {
-        "brace-expansion": "^2.0.1"
       }
     },
     "ms": {
@@ -1545,17 +1406,6 @@
         "xmlchars": "^2.2.0"
       }
     },
-    "shiki": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.11.1.tgz",
-      "integrity": "sha512-EugY9VASFuDqOexOgXR18ZV+TbFrQHeCpEYaXamO+SZlsnT/2LxuLBX25GGtIrwaEVFXUAbUQ601SWE2rMwWHA==",
-      "dev": true,
-      "requires": {
-        "jsonc-parser": "^3.0.0",
-        "vscode-oniguruma": "^1.6.1",
-        "vscode-textmate": "^6.0.0"
-      }
-    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -1618,18 +1468,6 @@
         "prelude-ls": "~1.1.2"
       }
     },
-    "typedoc": {
-      "version": "0.23.22",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.22.tgz",
-      "integrity": "sha512-5sJkjK60xp8A7YpcYniu3+Wf0QcgojEnhzHuCN+CkdpQkKRhOspon/9+sGTkGI8kjVkZs3KHrhltpQyVhRMVfw==",
-      "dev": true,
-      "requires": {
-        "lunr": "^2.3.9",
-        "marked": "^4.0.19",
-        "minimatch": "^5.1.0",
-        "shiki": "^0.11.1"
-      }
-    },
     "typescript": {
       "version": "4.6.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
@@ -1640,18 +1478,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true
-    },
-    "vscode-oniguruma": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
-      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
-      "dev": true
-    },
-    "vscode-textmate": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-6.0.0.tgz",
-      "integrity": "sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==",
       "dev": true
     },
     "w3c-hr-time": {

--- a/package.json
+++ b/package.json
@@ -11,15 +11,13 @@
     "dist/**/*"
   ],
   "scripts": {
-    "build-docs": "node make-webgpu-docs.mjs",
-    "build-ci": "npm run build-docs",
+    "test": "for t in tests/* ; do (cd \"$t\" && npm i && npm test); done",
+    "build-docs": "cd tsdoc-src && npm ci && npm run build",
     "generate": "bikeshed-to-ts --in ./gpuweb/spec/index.bs --out ./generated/index.d.ts --forceGlobal --nominal && prettier -w generated/index.d.ts",
     "format": "prettier -w dist/index.d.ts"
   },
   "devDependencies": {
     "bikeshed-to-ts": "github:toji/bikeshed-to-ts",
-    "prettier": "^2.2.1",
-    "typedoc": "^0.23.22",
-    "typescript": "4.6.4"
+    "prettier": "^2.2.1"
   }
 }

--- a/tsdoc-src/.gitignore
+++ b/tsdoc-src/.gitignore
@@ -1,0 +1,2 @@
+/out
+/webgpu.ts

--- a/tsdoc-src/generate-webgpu-ts.mjs
+++ b/tsdoc-src/generate-webgpu-ts.mjs
@@ -1,8 +1,7 @@
 import fs from 'fs';
-import TypeDoc from 'typedoc';
 
 async function main() {
-  let ts = fs.readFileSync('./dist/index.d.ts', {encoding: 'utf-8'});
+  let ts = fs.readFileSync('../dist/index.d.ts', {encoding: 'utf-8'});
   ts = ts
     // export interfaces.
     .replace(/\ninterface /g, '\nexport interface ')
@@ -30,21 +29,7 @@ async function main() {
    \\*/
   readonly __brand: ".*?";`.replace(/sss\*/g, '\\*').replace(/\s+/g, '\\s+'), 'g'), '');
 
-  fs.writeFileSync('./generated/webgpu.ts', ts);
-
-  const app = new TypeDoc.Application();
-  app.options.addReader(new TypeDoc.TSConfigReader());
-  app.options.addReader(new TypeDoc.TypeDocReader());
-
-  app.bootstrap({
-    entryPoints: ['./generated/webgpu.ts'],
-  });
-
-  const project = app.convert();
-  if (project) {
-    const outputDir = 'out';
-    await app.generateDocs(project, outputDir);
-  }
+  fs.writeFileSync('./webgpu.ts', ts);
 }
 
 main();

--- a/tsdoc-src/package-lock.json
+++ b/tsdoc-src/package-lock.json
@@ -1,0 +1,138 @@
+{
+  "name": "tsdoc-src",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "@types/dom-webcodecs": "0.1.3",
+        "typedoc": "^0.23.22",
+        "typescript": "4.6.4"
+      }
+    },
+    "node_modules/@types/dom-webcodecs": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@types/dom-webcodecs/-/dom-webcodecs-0.1.3.tgz",
+      "integrity": "sha512-MEUfHAnXifFqUbY51WK1f9y3NyupMqBhcRwCpl+UtHcl40Au3ijhahI37bblMoNmAOlU/33KMCkN4usdE1kJjg==",
+      "dev": true
+    },
+    "node_modules/ansi-sequence-parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.0.tgz",
+      "integrity": "sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ==",
+      "dev": true
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
+    },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
+    "node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "dev": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
+      "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/shiki": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.2.tgz",
+      "integrity": "sha512-ltSZlSLOuSY0M0Y75KA+ieRaZ0Trf5Wl3gutE7jzLuIcWxLp5i/uEnLoQWNvgKXQ5OMpGkJnVMRLAuzjc0LJ2A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-sequence-parser": "^1.1.0",
+        "jsonc-parser": "^3.2.0",
+        "vscode-oniguruma": "^1.7.0",
+        "vscode-textmate": "^8.0.0"
+      }
+    },
+    "node_modules/typedoc": {
+      "version": "0.23.28",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.28.tgz",
+      "integrity": "sha512-9x1+hZWTHEQcGoP7qFmlo4unUoVJLB0H/8vfO/7wqTnZxg4kPuji9y3uRzEu0ZKez63OJAUmiGhUrtukC6Uj3w==",
+      "dev": true,
+      "dependencies": {
+        "lunr": "^2.3.9",
+        "marked": "^4.2.12",
+        "minimatch": "^7.1.3",
+        "shiki": "^0.14.1"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 14.14"
+      },
+      "peerDependencies": {
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+      "dev": true
+    },
+    "node_modules/vscode-textmate": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
+      "dev": true
+    }
+  }
+}

--- a/tsdoc-src/package.json
+++ b/tsdoc-src/package.json
@@ -1,0 +1,10 @@
+{
+  "scripts": {
+    "build": "node generate-webgpu-ts.mjs && typedoc --treatWarningsAsErrors ./webgpu.ts"
+  },
+  "devDependencies": {
+    "@types/dom-webcodecs": "0.1.3",
+    "typedoc": "^0.23.22",
+    "typescript": "4.6.4"
+  }
+}

--- a/tsdoc-src/tsconfig.json
+++ b/tsdoc-src/tsconfig.json
@@ -19,7 +19,7 @@
     ],
   },
   "include": [
-    "./generated/webgpu.ts"
+    "./webgpu.ts"
   ],
   "exclude": [
     "node_modules",

--- a/tsdoc-src/typedoc.json
+++ b/tsdoc-src/typedoc.json
@@ -1,8 +1,9 @@
 {
     "$schema": "https://typedoc.org/schema.json",
-    "entryPoints": ["./generated/webgpu.ts"],
+    "entryPoints": ["./webgpu.ts"],
     "out": "out",
     "readme": "none",
     "name": "WebGPU API reference",
+    "validation": false,
     "disableSources": true
 }


### PR DESCRIPTION
The tsdoc build broke recently because of the inclusion of VideoFrame. This fixes that, and prevents it from happening again. It also moves the build to a subdirectory cleans up the dependencies for more tests in the next PR.

I had to replace the TypeDoc API usage with a command-line invocation because I can't figure out how to enable treatWarningsAsErrors and then exit>0 in the API usage.