### PR TITLE
Adds just unorm-10-10-10-2 vertex format

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -419,7 +419,8 @@ type GPUVertexFormat =
     | "sint32"
     | "sint32x2"
     | "sint32x3"
-    | "sint32x4";
+    | "sint32x4"
+    | "unorm10-10-10-2";
 type GPUVertexStepMode =
 
     | "vertex"


### PR DESCRIPTION
I'm not sure which commands I missed running in https://github.com/gpuweb/types/pull/138 but this bit was missing. @Kangz Please merge and update types to 0.1.37.
Sorry for the noise.