### PR TITLE
Update install section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ See the [TypeScript handbook](http://www.typescriptlang.org/docs/handbook/declar
 
 ### Install
 
-- npm: `npm install --save @webgpu/types`
-- yarn: `yarn add @webgpu/types`
+- npm: `npm install --save-dev @webgpu/types`
+- yarn: `yarn add --dev @webgpu/types`
+- pnpm: `pnpm add -D @webgpu/types`
 
 If you are on TypeScript < 5.1, you will also need to install `@types/dom-webcodecs`
 as a sibling dependency. The version you need depends on the TypeScript version;


### PR DESCRIPTION
This pull request updates the installation section of the README to recommend installing @webgpu/types as a development dependency rather than a production dependency. The changes reflect the more common use case where @webgpu/types is used during development for type checking and not required in the production build.

The updated installation commands are as follows:

For npm users, the command has been changed from npm install --save @webgpu/types to npm install --save-dev @webgpu/types.
For yarn users, the command has been changed from yarn add @webgpu/types to yarn add --dev @webgpu/types.
Additionally, I've added the installation command for pnpm users: pnpm add -D @webgpu/types.
These changes ensure that the package is added to the devDependencies section of the package.json, which is more appropriate for type definitions that are typically not needed in the final production bundle.

Please consider merging this pull request to make the installation instructions clearer and more accurate for developers using @webgpu/types.