### PR TITLE
Add missing constructors, remove non-existent interfaces/prototypes/constructors

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -3167,25 +3167,6 @@ interface Navigator
 interface WorkerNavigator
   extends NavigatorGPU {}
 
-interface GPUBufferUsage {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
-  readonly __brand: "GPUBufferUsage";
-  readonly MAP_READ: GPUFlagsConstant;
-  readonly MAP_WRITE: GPUFlagsConstant;
-  readonly COPY_SRC: GPUFlagsConstant;
-  readonly COPY_DST: GPUFlagsConstant;
-  readonly INDEX: GPUFlagsConstant;
-  readonly VERTEX: GPUFlagsConstant;
-  readonly UNIFORM: GPUFlagsConstant;
-  readonly STORAGE: GPUFlagsConstant;
-  readonly INDIRECT: GPUFlagsConstant;
-  readonly QUERY_RESOLVE: GPUFlagsConstant;
-}
-
 declare var GPUBufferUsage: {
   readonly MAP_READ: GPUFlagsConstant;
   readonly MAP_WRITE: GPUFlagsConstant;
@@ -3199,20 +3180,6 @@ declare var GPUBufferUsage: {
   readonly QUERY_RESOLVE: GPUFlagsConstant;
 };
 
-interface GPUColorWrite {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
-  readonly __brand: "GPUColorWrite";
-  readonly RED: GPUFlagsConstant;
-  readonly GREEN: GPUFlagsConstant;
-  readonly BLUE: GPUFlagsConstant;
-  readonly ALPHA: GPUFlagsConstant;
-  readonly ALL: GPUFlagsConstant;
-}
-
 declare var GPUColorWrite: {
   readonly RED: GPUFlagsConstant;
   readonly GREEN: GPUFlagsConstant;
@@ -3221,53 +3188,16 @@ declare var GPUColorWrite: {
   readonly ALL: GPUFlagsConstant;
 };
 
-interface GPUMapMode {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
-  readonly __brand: "GPUMapMode";
-  readonly READ: GPUFlagsConstant;
-  readonly WRITE: GPUFlagsConstant;
-}
-
 declare var GPUMapMode: {
   readonly READ: GPUFlagsConstant;
   readonly WRITE: GPUFlagsConstant;
 };
-
-interface GPUShaderStage {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
-  readonly __brand: "GPUShaderStage";
-  readonly VERTEX: GPUFlagsConstant;
-  readonly FRAGMENT: GPUFlagsConstant;
-  readonly COMPUTE: GPUFlagsConstant;
-}
 
 declare var GPUShaderStage: {
   readonly VERTEX: GPUFlagsConstant;
   readonly FRAGMENT: GPUFlagsConstant;
   readonly COMPUTE: GPUFlagsConstant;
 };
-
-interface GPUTextureUsage {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
-  readonly __brand: "GPUTextureUsage";
-  readonly COPY_SRC: GPUFlagsConstant;
-  readonly COPY_DST: GPUFlagsConstant;
-  readonly TEXTURE_BINDING: GPUFlagsConstant;
-  readonly STORAGE_BINDING: GPUFlagsConstant;
-  readonly RENDER_ATTACHMENT: GPUFlagsConstant;
-}
 
 declare var GPUTextureUsage: {
   readonly COPY_SRC: GPUFlagsConstant;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1970,6 +1970,7 @@ interface GPUAdapterInfo {
 
 declare var GPUAdapterInfo: {
   prototype: GPUAdapterInfo;
+  new (): never;
 };
 
 interface GPUBindGroup

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -3187,7 +3187,6 @@ interface GPUBufferUsage {
 }
 
 declare var GPUBufferUsage: {
-  prototype: GPUBufferUsage;
   readonly MAP_READ: GPUFlagsConstant;
   readonly MAP_WRITE: GPUFlagsConstant;
   readonly COPY_SRC: GPUFlagsConstant;
@@ -3215,7 +3214,6 @@ interface GPUColorWrite {
 }
 
 declare var GPUColorWrite: {
-  prototype: GPUColorWrite;
   readonly RED: GPUFlagsConstant;
   readonly GREEN: GPUFlagsConstant;
   readonly BLUE: GPUFlagsConstant;
@@ -3235,8 +3233,6 @@ interface GPUMapMode {
 }
 
 declare var GPUMapMode: {
-  prototype: GPUMapMode;
-  new (): never;
   readonly READ: GPUFlagsConstant;
   readonly WRITE: GPUFlagsConstant;
 };
@@ -3254,7 +3250,6 @@ interface GPUShaderStage {
 }
 
 declare var GPUShaderStage: {
-  prototype: GPUShaderStage;
   readonly VERTEX: GPUFlagsConstant;
   readonly FRAGMENT: GPUFlagsConstant;
   readonly COMPUTE: GPUFlagsConstant;
@@ -3275,7 +3270,6 @@ interface GPUTextureUsage {
 }
 
 declare var GPUTextureUsage: {
-  prototype: GPUTextureUsage;
   readonly COPY_SRC: GPUFlagsConstant;
   readonly COPY_DST: GPUFlagsConstant;
   readonly TEXTURE_BINDING: GPUFlagsConstant;


### PR DESCRIPTION
A constructor is needed in GPUAdapterInfo for `instanceof GPUAdapterInfo` to work (https://github.com/gpuweb/cts/pull/3679/files#diff-b1c3098d2cfb3e28e1d76d21e07c37131894fe5eeb3f55f0646c15b0f3db2b02R25).

Also, after the spec switch from IDL `interface`s to `namespace`s for bitflags, there are no longer prototypes or constructors on those objects, at least according to Chromium:
- `GPUBufferUsage instanceof Function` is false
- `'prototype' in GPUBufferUsage` is false
- `GPUBufferUsage.__proto__ === ({}).__proto__`

And they don't name types so I've removed the TS `interface`s too.
Associated CTS fixes in https://github.com/gpuweb/cts/pull/3770