### PR TITLE
Remove non-standard GPUAdapter requestAdapterInfo() method

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1947,8 +1947,6 @@ interface GPUAdapter {
   requestDevice(
     descriptor?: GPUDeviceDescriptor
   ): Promise<GPUDevice>;
-  /** @deprecated Use `adapter.info` instead (once available in browsers). */
-  requestAdapterInfo(): Promise<GPUAdapterInfo>;
 }
 
 declare var GPUAdapter: {


### PR DESCRIPTION
This PR removes the non-standard GPUAdapter requestAdapterInfo() method which was replaced with the GPUAdapter info attribute.