### PR TITLE
Add proposed textureBindingViewDimension

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Most or all of these should be fixed in the generator over time.
 The following differences are TODO: should be changed in the final result.
 
 - Deprecated items should be removed.
+- Addition of Compatibility Mode items like `textureBindingViewDimension`.
 
 The following differences will remain.
 

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1619,6 +1619,17 @@ interface GPUTextureDescriptor
    * </div>
    */
   viewFormats?: Iterable<GPUTextureFormat>;
+  /**
+   * **PROPOSED** addition for Compatibility Mode:
+   * <https://github.com/gpuweb/gpuweb/blob/main/proposals/compatibility-mode.md#1-texture-view-dimension-may-be-specified>
+   *
+   * > [In compatibility mode,]
+   * > When specifying a texture, a textureBindingViewDimension property
+   * > determines the views which can be bound from that texture for sampling.
+   * > Binding a view of a different dimension for sampling than specified at
+   * > texture creation time will cause a validation error.
+   */
+  textureBindingViewDimension?: GPUTextureViewDimension;
 }
 
 interface GPUTextureViewDescriptor


### PR DESCRIPTION
This is not standardized, but there is no harm in the types allowing it because standard implementations will simply ignore it.