### PR TITLE
Add Event Types

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -2447,6 +2447,10 @@ declare var GPUComputePipeline: {
   new (): never;
 };
 
+interface GPUDeviceEventMap {
+  uncapturederror: GPUUncapturedErrorEvent;
+}
+
 interface GPUDevice
   extends EventTarget,
     GPUObjectBase {
@@ -2631,6 +2635,45 @@ interface GPUDevice
         ev: GPUUncapturedErrorEvent
       ) => any)
     | null;
+
+  addEventListener<
+    K extends keyof GPUDeviceEventMap
+  >(
+    type: K,
+    listener: (
+      this: GPUDevice,
+      ev: GPUDeviceEventMap[K]
+    ) => any,
+    options?:
+      | boolean
+      | AddEventListenerOptions
+  ): void;
+  addEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?:
+      | boolean
+      | AddEventListenerOptions
+  ): void;
+  removeEventListener<
+    K extends keyof GPUDeviceEventMap
+  >(
+    type: K,
+    listener: (
+      this: GPUDevice,
+      ev: GPUDeviceEventMap[K]
+    ) => any,
+    options?:
+      | boolean
+      | EventListenerOptions
+  ): void;
+  removeEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?:
+      | boolean
+      | EventListenerOptions
+  ): void;
 }
 
 declare var GPUDevice: {

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -2447,7 +2447,8 @@ declare var GPUComputePipeline: {
   new (): never;
 };
 
-interface GPUDeviceEventMap {
+/** @internal */
+interface __GPUDeviceEventMap {
   uncapturederror: GPUUncapturedErrorEvent;
 }
 
@@ -2637,12 +2638,12 @@ interface GPUDevice
     | null;
 
   addEventListener<
-    K extends keyof GPUDeviceEventMap
+    K extends keyof __GPUDeviceEventMap
   >(
     type: K,
     listener: (
       this: GPUDevice,
-      ev: GPUDeviceEventMap[K]
+      ev: __GPUDeviceEventMap[K]
     ) => any,
     options?:
       | boolean
@@ -2656,12 +2657,12 @@ interface GPUDevice
       | AddEventListenerOptions
   ): void;
   removeEventListener<
-    K extends keyof GPUDeviceEventMap
+    K extends keyof __GPUDeviceEventMap
   >(
     type: K,
     listener: (
       this: GPUDevice,
-      ev: GPUDeviceEventMap[K]
+      ev: __GPUDeviceEventMap[K]
     ) => any,
     options?:
       | boolean


### PR DESCRIPTION
this makes `addEventListener` on `GPUDevice` have the right type information.

![Screenshot 2025-01-29 at 11 50 18](https://github.com/user-attachments/assets/f057ab5e-23ff-4661-b1d1-6e30f102a6fe)

![Screenshot 2025-01-29 at 11 51 12](https://github.com/user-attachments/assets/14684566-34d4-4396-9071-4aeb59c5ec47)

I wasn't sure how to add it to the generated file. 