### PR TITLE
Roll fixes from bikeshed-to-ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,7 @@ Please contribute a PR to add instructions for other setups or improve existing 
 
 Most or all of these should be fixed in the generator over time.
 
-- `Array` changed to `Iterable` for WebIDL `sequence`s in argument positions (but not in return positions).
 - `any` changed to `object` for WebIDL `object`.
-- `| null` changed to `| null | undefined` for WebIDL nullable items (`T?`).
 
 The following differences are TODO: should be changed in the final result.
 

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1999,11 +1999,7 @@ interface NavigatorGPU {
 }
 
 interface GPU {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPU";
   /**
    * Requests an adapter from the user agent.
@@ -2034,11 +2030,7 @@ declare var GPU: {
 };
 
 interface GPUAdapter {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUAdapter";
   /**
    * The set of values in `this`.{@link GPUAdapter#[[adapter]]}.{@link adapter#[[features]]}.
@@ -2086,11 +2078,7 @@ declare var GPUAdapter: {
 };
 
 interface GPUAdapterInfo {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUAdapterInfo";
   /**
    * The name of the vendor of the adapter, if available. Empty string otherwise.
@@ -2140,11 +2128,7 @@ declare var GPUAdapterInfo: {
 
 interface GPUBindGroup
   extends GPUObjectBase {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUBindGroup";
 }
 
@@ -2155,11 +2139,7 @@ declare var GPUBindGroup: {
 
 interface GPUBindGroupLayout
   extends GPUObjectBase {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUBindGroupLayout";
 }
 
@@ -2170,11 +2150,7 @@ declare var GPUBindGroupLayout: {
 
 interface GPUBuffer
   extends GPUObjectBase {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUBuffer";
   readonly size: GPUSize64Out;
   readonly usage: GPUFlagsConstant;
@@ -2229,11 +2205,7 @@ declare var GPUBuffer: {
 };
 
 interface GPUCanvasContext {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUCanvasContext";
   /**
    * The canvas this context was created from.
@@ -2274,11 +2246,7 @@ declare var GPUCanvasContext: {
 
 interface GPUCommandBuffer
   extends GPUObjectBase {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUCommandBuffer";
 }
 
@@ -2291,11 +2259,7 @@ interface GPUCommandEncoder
   extends GPUObjectBase,
     GPUCommandsMixin,
     GPUDebugCommandsMixin {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUCommandEncoder";
   /**
    * Begins encoding a render pass described by `descriptor`.
@@ -2410,11 +2374,7 @@ declare var GPUCommandEncoder: {
 };
 
 interface GPUCompilationInfo {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUCompilationInfo";
   readonly messages: ReadonlyArray<GPUCompilationMessage>;
 }
@@ -2425,11 +2385,7 @@ declare var GPUCompilationInfo: {
 };
 
 interface GPUCompilationMessage {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUCompilationMessage";
   /**
    * The human-readable, localizable text for this compilation message.
@@ -2493,11 +2449,7 @@ interface GPUComputePassEncoder
     GPUCommandsMixin,
     GPUDebugCommandsMixin,
     GPUBindingCommandsMixin {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUComputePassEncoder";
   /**
    * Sets the current {@link GPUComputePipeline}.
@@ -2546,11 +2498,7 @@ declare var GPUComputePassEncoder: {
 interface GPUComputePipeline
   extends GPUObjectBase,
     GPUPipelineBase {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUComputePipeline";
 }
 
@@ -2562,11 +2510,7 @@ declare var GPUComputePipeline: {
 interface GPUDevice
   extends EventTarget,
     GPUObjectBase {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUDevice";
   /**
    * A set containing the {@link GPUFeatureName} values of the features
@@ -2751,11 +2695,7 @@ declare var GPUDevice: {
 };
 
 interface GPUDeviceLostInfo {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUDeviceLostInfo";
   readonly reason: GPUDeviceLostReason;
   readonly message: string;
@@ -2792,11 +2732,7 @@ declare var GPUError: {
 
 interface GPUExternalTexture
   extends GPUObjectBase {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUExternalTexture";
 }
 
@@ -2807,11 +2743,7 @@ declare var GPUExternalTexture: {
 
 interface GPUInternalError
   extends GPUError {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUInternalError";
 }
 
@@ -2824,11 +2756,7 @@ declare var GPUInternalError: {
 
 interface GPUOutOfMemoryError
   extends GPUError {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUOutOfMemoryError";
 }
 
@@ -2841,11 +2769,7 @@ declare var GPUOutOfMemoryError: {
 
 interface GPUPipelineError
   extends DOMException {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUPipelineError";
   /**
    * A read-only slot-backed attribute exposing the type of error encountered in pipeline creation
@@ -2870,11 +2794,7 @@ declare var GPUPipelineError: {
 
 interface GPUPipelineLayout
   extends GPUObjectBase {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUPipelineLayout";
 }
 
@@ -2885,11 +2805,7 @@ declare var GPUPipelineLayout: {
 
 interface GPUQuerySet
   extends GPUObjectBase {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUQuerySet";
   /**
    * Destroys the {@link GPUQuerySet}.
@@ -2912,11 +2828,7 @@ declare var GPUQuerySet: {
 
 interface GPUQueue
   extends GPUObjectBase {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUQueue";
   /**
    * Schedules the execution of the command buffers by the GPU on this queue.
@@ -2992,11 +2904,7 @@ declare var GPUQueue: {
 
 interface GPURenderBundle
   extends GPUObjectBase {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPURenderBundle";
 }
 
@@ -3011,11 +2919,7 @@ interface GPURenderBundleEncoder
     GPUDebugCommandsMixin,
     GPUBindingCommandsMixin,
     GPURenderCommandsMixin {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPURenderBundleEncoder";
   /**
    * Completes recording of the render bundle commands sequence.
@@ -3037,11 +2941,7 @@ interface GPURenderPassEncoder
     GPUDebugCommandsMixin,
     GPUBindingCommandsMixin,
     GPURenderCommandsMixin {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPURenderPassEncoder";
   /**
    * Sets the viewport used during the rasterization stage to linearly map from
@@ -3129,11 +3029,7 @@ declare var GPURenderPassEncoder: {
 interface GPURenderPipeline
   extends GPUObjectBase,
     GPUPipelineBase {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPURenderPipeline";
 }
 
@@ -3144,11 +3040,7 @@ declare var GPURenderPipeline: {
 
 interface GPUSampler
   extends GPUObjectBase {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUSampler";
 }
 
@@ -3159,11 +3051,7 @@ declare var GPUSampler: {
 
 interface GPUShaderModule
   extends GPUObjectBase {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUShaderModule";
   /**
    * Returns any messages generated during the {@link GPUShaderModule}'s compilation.
@@ -3182,11 +3070,7 @@ type GPUSupportedFeatures =
   ReadonlySet<string>;
 
 interface GPUSupportedLimits {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUSupportedLimits";
   readonly maxTextureDimension1D: number;
   readonly maxTextureDimension2D: number;
@@ -3235,11 +3119,7 @@ declare var GPUSupportedLimits: {
 
 interface GPUTexture
   extends GPUObjectBase {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUTexture";
   /**
    * Creates a {@link GPUTextureView}.
@@ -3293,11 +3173,7 @@ declare var GPUTexture: {
 
 interface GPUTextureView
   extends GPUObjectBase {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUTextureView";
 }
 
@@ -3308,11 +3184,7 @@ declare var GPUTextureView: {
 
 interface GPUUncapturedErrorEvent
   extends Event {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUUncapturedErrorEvent";
   /**
    * A slot-backed attribute holding an object representing the error that was uncaptured.
@@ -3331,11 +3203,7 @@ declare var GPUUncapturedErrorEvent: {
 
 interface GPUValidationError
   extends GPUError {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUValidationError";
 }
 

--- a/generated/index.d.ts
+++ b/generated/index.d.ts
@@ -1771,11 +1771,7 @@ interface NavigatorGPU {
 }
 
 interface GPU {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPU";
   /**
    * Requests an adapter from the user agent.
@@ -1802,14 +1798,11 @@ interface GPU {
 
 declare var GPU: {
   prototype: GPU;
+  new (): never;
 };
 
 interface GPUAdapter {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUAdapter";
   readonly features: GPUSupportedFeatures;
   readonly limits: GPUSupportedLimits;
@@ -1827,14 +1820,11 @@ interface GPUAdapter {
 
 declare var GPUAdapter: {
   prototype: GPUAdapter;
+  new (): never;
 };
 
 interface GPUAdapterInfo {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUAdapterInfo";
   readonly vendor: string;
   readonly architecture: string;
@@ -1847,43 +1837,34 @@ interface GPUAdapterInfo {
 
 declare var GPUAdapterInfo: {
   prototype: GPUAdapterInfo;
+  new (): never;
 };
 
 interface GPUBindGroup
   extends GPUObjectBase {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUBindGroup";
 }
 
 declare var GPUBindGroup: {
   prototype: GPUBindGroup;
+  new (): never;
 };
 
 interface GPUBindGroupLayout
   extends GPUObjectBase {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUBindGroupLayout";
 }
 
 declare var GPUBindGroupLayout: {
   prototype: GPUBindGroupLayout;
+  new (): never;
 };
 
 interface GPUBuffer
   extends GPUObjectBase {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUBuffer";
   readonly size: GPUSize64Out;
   readonly usage: GPUFlagsConstant;
@@ -1934,14 +1915,11 @@ interface GPUBuffer
 
 declare var GPUBuffer: {
   prototype: GPUBuffer;
+  new (): never;
 };
 
 interface GPUCanvasContext {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUCanvasContext";
   readonly canvas:
     | HTMLCanvasElement
@@ -1974,31 +1952,25 @@ interface GPUCanvasContext {
 
 declare var GPUCanvasContext: {
   prototype: GPUCanvasContext;
+  new (): never;
 };
 
 interface GPUCommandBuffer
   extends GPUObjectBase {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUCommandBuffer";
 }
 
 declare var GPUCommandBuffer: {
   prototype: GPUCommandBuffer;
+  new (): never;
 };
 
 interface GPUCommandEncoder
   extends GPUObjectBase,
     GPUCommandsMixin,
     GPUDebugCommandsMixin {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUCommandEncoder";
   /**
    * Begins encoding a render pass described by `descriptor`.
@@ -2109,28 +2081,22 @@ interface GPUCommandEncoder
 
 declare var GPUCommandEncoder: {
   prototype: GPUCommandEncoder;
+  new (): never;
 };
 
 interface GPUCompilationInfo {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUCompilationInfo";
   readonly messages: ReadonlyArray<GPUCompilationMessage>;
 }
 
 declare var GPUCompilationInfo: {
   prototype: GPUCompilationInfo;
+  new (): never;
 };
 
 interface GPUCompilationMessage {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUCompilationMessage";
   readonly message: string;
   readonly type: GPUCompilationMessageType;
@@ -2142,6 +2108,7 @@ interface GPUCompilationMessage {
 
 declare var GPUCompilationMessage: {
   prototype: GPUCompilationMessage;
+  new (): never;
 };
 
 interface GPUComputePassEncoder
@@ -2149,11 +2116,7 @@ interface GPUComputePassEncoder
     GPUCommandsMixin,
     GPUDebugCommandsMixin,
     GPUBindingCommandsMixin {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUComputePassEncoder";
   /**
    * Sets the current {@link GPUComputePipeline}.
@@ -2196,31 +2159,25 @@ interface GPUComputePassEncoder
 
 declare var GPUComputePassEncoder: {
   prototype: GPUComputePassEncoder;
+  new (): never;
 };
 
 interface GPUComputePipeline
   extends GPUObjectBase,
     GPUPipelineBase {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUComputePipeline";
 }
 
 declare var GPUComputePipeline: {
   prototype: GPUComputePipeline;
+  new (): never;
 };
 
 interface GPUDevice
   extends EventTarget,
     GPUObjectBase {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUDevice";
   readonly features: GPUSupportedFeatures;
   readonly limits: GPUSupportedLimits;
@@ -2376,14 +2333,11 @@ interface GPUDevice
 
 declare var GPUDevice: {
   prototype: GPUDevice;
+  new (): never;
 };
 
 interface GPUDeviceLostInfo {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUDeviceLostInfo";
   readonly reason: GPUDeviceLostReason;
   readonly message: string;
@@ -2391,6 +2345,7 @@ interface GPUDeviceLostInfo {
 
 declare var GPUDeviceLostInfo: {
   prototype: GPUDeviceLostInfo;
+  new (): never;
 };
 
 interface GPUError {
@@ -2399,29 +2354,23 @@ interface GPUError {
 
 declare var GPUError: {
   prototype: GPUError;
+  new (): never;
 };
 
 interface GPUExternalTexture
   extends GPUObjectBase {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUExternalTexture";
 }
 
 declare var GPUExternalTexture: {
   prototype: GPUExternalTexture;
+  new (): never;
 };
 
 interface GPUInternalError
   extends GPUError {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUInternalError";
 }
 
@@ -2429,16 +2378,12 @@ declare var GPUInternalError: {
   prototype: GPUInternalError;
   new (
     message: string
-  );
+  ): GPUInternalError;
 };
 
 interface GPUOutOfMemoryError
   extends GPUError {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUOutOfMemoryError";
 }
 
@@ -2446,16 +2391,12 @@ declare var GPUOutOfMemoryError: {
   prototype: GPUOutOfMemoryError;
   new (
     message: string
-  );
+  ): GPUOutOfMemoryError;
 };
 
 interface GPUPipelineError
   extends DOMException {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUPipelineError";
   readonly reason: GPUPipelineErrorReason;
 }
@@ -2465,30 +2406,23 @@ declare var GPUPipelineError: {
   new (
     message?: string,
     options: GPUPipelineErrorInit
-  );
+  ): GPUPipelineError;
 };
 
 interface GPUPipelineLayout
   extends GPUObjectBase {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUPipelineLayout";
 }
 
 declare var GPUPipelineLayout: {
   prototype: GPUPipelineLayout;
+  new (): never;
 };
 
 interface GPUQuerySet
   extends GPUObjectBase {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUQuerySet";
   /**
    * Destroys the {@link GPUQuerySet}.
@@ -2500,15 +2434,12 @@ interface GPUQuerySet
 
 declare var GPUQuerySet: {
   prototype: GPUQuerySet;
+  new (): never;
 };
 
 interface GPUQueue
   extends GPUObjectBase {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUQueue";
   /**
    * Schedules the execution of the command buffers by the GPU on this queue.
@@ -2572,20 +2503,18 @@ interface GPUQueue
 
 declare var GPUQueue: {
   prototype: GPUQueue;
+  new (): never;
 };
 
 interface GPURenderBundle
   extends GPUObjectBase {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPURenderBundle";
 }
 
 declare var GPURenderBundle: {
   prototype: GPURenderBundle;
+  new (): never;
 };
 
 interface GPURenderBundleEncoder
@@ -2594,11 +2523,7 @@ interface GPURenderBundleEncoder
     GPUDebugCommandsMixin,
     GPUBindingCommandsMixin,
     GPURenderCommandsMixin {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPURenderBundleEncoder";
   /**
    * Completes recording of the render bundle commands sequence.
@@ -2611,6 +2536,7 @@ interface GPURenderBundleEncoder
 
 declare var GPURenderBundleEncoder: {
   prototype: GPURenderBundleEncoder;
+  new (): never;
 };
 
 interface GPURenderPassEncoder
@@ -2619,11 +2545,7 @@ interface GPURenderPassEncoder
     GPUDebugCommandsMixin,
     GPUBindingCommandsMixin,
     GPURenderCommandsMixin {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPURenderPassEncoder";
   /**
    * Sets the viewport used during the rasterization stage to linearly map from
@@ -2705,44 +2627,35 @@ interface GPURenderPassEncoder
 
 declare var GPURenderPassEncoder: {
   prototype: GPURenderPassEncoder;
+  new (): never;
 };
 
 interface GPURenderPipeline
   extends GPUObjectBase,
     GPUPipelineBase {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPURenderPipeline";
 }
 
 declare var GPURenderPipeline: {
   prototype: GPURenderPipeline;
+  new (): never;
 };
 
 interface GPUSampler
   extends GPUObjectBase {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUSampler";
 }
 
 declare var GPUSampler: {
   prototype: GPUSampler;
+  new (): never;
 };
 
 interface GPUShaderModule
   extends GPUObjectBase {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUShaderModule";
   /**
    * Returns any messages generated during the {@link GPUShaderModule}'s compilation.
@@ -2754,17 +2667,14 @@ interface GPUShaderModule
 
 declare var GPUShaderModule: {
   prototype: GPUShaderModule;
+  new (): never;
 };
 
 type GPUSupportedFeatures =
   ReadonlySet<string>;
 
 interface GPUSupportedLimits {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUSupportedLimits";
   readonly maxTextureDimension1D: number;
   readonly maxTextureDimension2D: number;
@@ -2801,15 +2711,12 @@ interface GPUSupportedLimits {
 
 declare var GPUSupportedLimits: {
   prototype: GPUSupportedLimits;
+  new (): never;
 };
 
 interface GPUTexture
   extends GPUObjectBase {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUTexture";
   /**
    * Creates a {@link GPUTextureView}.
@@ -2834,29 +2741,23 @@ interface GPUTexture
 
 declare var GPUTexture: {
   prototype: GPUTexture;
+  new (): never;
 };
 
 interface GPUTextureView
   extends GPUObjectBase {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUTextureView";
 }
 
 declare var GPUTextureView: {
   prototype: GPUTextureView;
+  new (): never;
 };
 
 interface GPUUncapturedErrorEvent
   extends Event {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUUncapturedErrorEvent";
   readonly error: GPUError;
 }
@@ -2866,16 +2767,12 @@ declare var GPUUncapturedErrorEvent: {
   new (
     type: string,
     gpuUncapturedErrorEventInitDict: GPUUncapturedErrorEventInit
-  );
+  ): GPUUncapturedErrorEvent;
 };
 
 interface GPUValidationError
   extends GPUError {
-  /**
-   * Nominal type branding.
-   * https://github.com/microsoft/TypeScript/pull/33038
-   * @internal
-   */
+  /** @internal Workaround for [nominal typing](https://github.com/microsoft/TypeScript/pull/33038). */
   readonly __brand: "GPUValidationError";
 }
 
@@ -2883,7 +2780,7 @@ declare var GPUValidationError: {
   prototype: GPUValidationError;
   new (
     message: string
-  );
+  ): GPUValidationError;
 };
 
 type WGSLLanguageFeatures =
@@ -2908,6 +2805,8 @@ interface GPUBufferUsage {
   readonly QUERY_RESOLVE: GPUFlagsConstant;
 }
 
+declare var GPUBufferUsage: GPUBufferUsage;
+
 interface GPUColorWrite {
   readonly RED: GPUFlagsConstant;
   readonly GREEN: GPUFlagsConstant;
@@ -2916,16 +2815,22 @@ interface GPUColorWrite {
   readonly ALL: GPUFlagsConstant;
 }
 
+declare var GPUColorWrite: GPUColorWrite;
+
 interface GPUMapMode {
   readonly READ: GPUFlagsConstant;
   readonly WRITE: GPUFlagsConstant;
 }
+
+declare var GPUMapMode: GPUMapMode;
 
 interface GPUShaderStage {
   readonly VERTEX: GPUFlagsConstant;
   readonly FRAGMENT: GPUFlagsConstant;
   readonly COMPUTE: GPUFlagsConstant;
 }
+
+declare var GPUShaderStage: GPUShaderStage;
 
 interface GPUTextureUsage {
   readonly COPY_SRC: GPUFlagsConstant;
@@ -2934,3 +2839,5 @@ interface GPUTextureUsage {
   readonly STORAGE_BINDING: GPUFlagsConstant;
   readonly RENDER_ATTACHMENT: GPUFlagsConstant;
 }
+
+declare var GPUTextureUsage: GPUTextureUsage;

--- a/package-lock.json
+++ b/package-lock.json
@@ -909,7 +909,6 @@
       }
     },
     "third_party/bikeshed-to-ts": {
-      "version": "1.2.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
- Roll fixes in bikeshed-to-ts. None of these affect `dist/` because they were previously done manually.
    - Add return types on constructors
    - Add `new (): never` for objects that can't be constructed
    - Translate `namespace`s into `interface`+`var` instead of just `interface`
- Nit in both bikeshed-to-ts and `dist/`
    - Make the nominal typing comment smaller since there are so many copies of it
- Update README