### PR TITLE
"Polyfill" AllowSharedBufferSource

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -6,13 +6,24 @@
 // Manually-written
 // *********************************************************************************************
 
+// AllowSharedBufferSource wasn't introduced until TypeScript 5.2.
+// But it also didn't include SharedArrayBuffer in the union.
+// This broke in ES2024 when ArrayBuffer gained some properties that SharedArrayBuffer didn't.
+// So, we use our own definition for AllowSharedBufferSource.
+
+type GPUAllowSharedBufferSource =
+
+    | BufferSource
+    | SharedArrayBuffer;
+
+// Stronger typing for getContext()
+
 interface HTMLCanvasElement {
   getContext(
     contextId:
       | "webgpu"
   ): GPUCanvasContext | null;
 }
-
 interface OffscreenCanvas {
   getContext(
     contextId:
@@ -21,32 +32,33 @@ interface OffscreenCanvas {
 }
 
 // Defined as an empty interface here to prevent errors when using these types in a worker.
+
 interface HTMLVideoElement {}
+
+// Strict types defined to help developers catch a common class of errors.
+// This interface defines depth as an undefined, which will cause a type check failure if someone
+// attempts to set depth rather than depthOrArrayLayers on a GPUExtent3D (an easy mistake to make.)
 
 type GPUOrigin2DStrict =
 
     | Iterable<GPUIntegerCoordinate>
     | GPUOrigin2DDictStrict;
-
 interface GPUOrigin2DDictStrict
   extends GPUOrigin2DDict {
   /** @deprecated Does not exist for GPUOrigin2D. */
   z?: undefined;
 }
-
 type GPUExtent3DStrict =
 
     | Iterable<GPUIntegerCoordinate>
     | GPUExtent3DDictStrict;
-
-// GPUExtent3DDictStrict is defined to help developers catch a common class of errors.
-// This interface defines depth as an undefined, which will cause a type check failure if someone
-// attempts to set depth rather than depthOrArrayLayers on a GPUExtent3D (an easy mistake to make.)
 interface GPUExtent3DDictStrict
   extends GPUExtent3DDict {
   /** @deprecated The correct name is `depthOrArrayLayers`. */
   depth?: undefined;
 }
+
+// Stronger typing for event listeners.
 
 /** @internal */
 interface __GPUDeviceEventMap {
@@ -2865,7 +2877,7 @@ interface GPUQueue
   writeBuffer(
     buffer: GPUBuffer,
     bufferOffset: GPUSize64,
-    data: AllowSharedBufferSource,
+    data: GPUAllowSharedBufferSource,
     dataOffset?: GPUSize64,
     size?: GPUSize64
   ): undefined;
@@ -2878,7 +2890,7 @@ interface GPUQueue
    */
   writeTexture(
     destination: GPUTexelCopyTextureInfo,
-    data: AllowSharedBufferSource,
+    data: GPUAllowSharedBufferSource,
     dataLayout: GPUTexelCopyBufferLayout,
     size: GPUExtent3DStrict
   ): undefined;

--- a/fix-generated.mjs
+++ b/fix-generated.mjs
@@ -3,6 +3,9 @@ import fs from 'fs';
 async function main() {
   let ts = fs.readFileSync('generated/index.d.ts', { encoding: 'utf-8' });
   ts = ts
+    // Replace broken AllowSharedBufferSource with GPUAllowSharedBufferSource
+    .replace(/AllowSharedBufferSource/g, 'GPUAllowSharedBufferSource')
+
     // convert [[#anchor]] to {@link spec_url}
     // convert [[#anchor|text]] to {@link spec_url|text}
     .replace(/([^#])\[\[([^\[].*?)\]\]/g, '$1{@link https://www.w3.org/TR/webgpu/$2}')

--- a/generated/index.d.ts
+++ b/generated/index.d.ts
@@ -2494,7 +2494,7 @@ interface GPUQueue
   writeBuffer(
     buffer: GPUBuffer,
     bufferOffset: GPUSize64,
-    data: AllowSharedBufferSource,
+    data: GPUAllowSharedBufferSource,
     dataOffset?: GPUSize64,
     size?: GPUSize64
   ): undefined;
@@ -2507,7 +2507,7 @@ interface GPUQueue
    */
   writeTexture(
     destination: GPUTexelCopyTextureInfo,
-    data: AllowSharedBufferSource,
+    data: GPUAllowSharedBufferSource,
     dataLayout: GPUTexelCopyBufferLayout,
     size: GPUExtent3D
   ): undefined;

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "dist/**/*"
   ],
   "scripts": {
-    "test": "for t in tests/*/ ; do (cd \"$t\" && npm i && npm test); done",
+    "test": "for t in tests/*/ ; do echo \"======== $t ========\" ; (cd \"$t\" && npm i && npm test); done",
     "build-docs": "cd tsdoc-src && npm ci && npm run build",
-    "generate": "bikeshed-to-ts --in ./gpuweb/spec/index.bs --out ./generated/index.d.ts --forceGlobal --nominal && node fix-generated-comments.mjs && prettier -w generated/index.d.ts",
+    "generate": "bikeshed-to-ts --in ./gpuweb/spec/index.bs --out ./generated/index.d.ts --forceGlobal --nominal && node fix-generated.mjs && prettier -w generated/index.d.ts",
     "format": "prettier -w dist/index.d.ts"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dist/**/*"
   ],
   "scripts": {
-    "test": "for t in tests/*/ ; do echo \"======== $t ========\" ; (cd \"$t\" && npm i && npm test); done",
+    "test": "for t in tests/*/ ; do echo \"\\n======== $t ========\" ; (cd \"$t\" && npm i && npm test); done",
     "build-docs": "cd tsdoc-src && npm ci && npm run build",
     "generate": "bikeshed-to-ts --in ./gpuweb/spec/index.bs --out ./generated/index.d.ts --forceGlobal --nominal && node fix-generated.mjs && prettier -w generated/index.d.ts",
     "format": "prettier -w dist/index.d.ts"

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,0 +1,3 @@
+export function test_writeBuffer(q: GPUQueue, b: GPUBuffer, sab: SharedArrayBuffer) {
+    q.writeBuffer(b, 0, sab);
+}

--- a/tests/ts4.6/index.ts
+++ b/tests/ts4.6/index.ts
@@ -1,1 +1,0 @@
-/// <reference types="@webgpu/types" />

--- a/tests/ts4.6/tsconfig.json
+++ b/tests/ts4.6/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../tsconfig.json",
-  "include": ["index.ts"]
+  "include": ["../index.ts"]
 }

--- a/tests/ts4.7/index.ts
+++ b/tests/ts4.7/index.ts
@@ -1,1 +1,0 @@
-/// <reference types="@webgpu/types" />

--- a/tests/ts4.7/tsconfig.json
+++ b/tests/ts4.7/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../tsconfig.json",
-  "include": ["index.ts"]
+  "include": ["../index.ts"]
 }

--- a/tests/ts4.9/index.ts
+++ b/tests/ts4.9/index.ts
@@ -1,1 +1,0 @@
-/// <reference types="@webgpu/types" />

--- a/tests/ts4.9/tsconfig.json
+++ b/tests/ts4.9/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../tsconfig.json",
-  "include": ["index.ts"]
+  "include": ["../index.ts"]
 }

--- a/tests/ts5.2/index.ts
+++ b/tests/ts5.2/index.ts
@@ -1,1 +1,0 @@
-/// <reference types="@webgpu/types" />

--- a/tests/ts5.2/tsconfig.json
+++ b/tests/ts5.2/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../tsconfig.json",
-  "include": ["index.ts"]
+  "include": ["../index.ts"]
 }

--- a/tests/ts5.8/index.ts
+++ b/tests/ts5.8/index.ts
@@ -1,1 +1,0 @@
-/// <reference types="@webgpu/types" />

--- a/tests/ts5.8/tsconfig.json
+++ b/tests/ts5.8/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../tsconfig.json",
-  "include": ["index.ts"]
+  "include": ["../index.ts"]
 }

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,9 +1,28 @@
 {
   "compilerOptions": {
-    "lib": ["DOM", "ESNext"],
-    "module": "ESNext",
     "noEmit": true,
+
+    "module": "ESNext",
+    "lib": ["DOM", "ESNext"],
+    "target": "ESNext",
+
+    // From https://github.com/tsconfig/bases/blob/main/bases/strictest.json
     "strict": true,
-    "target": "ESNext"
+    "allowUnusedLabels": false,
+    "allowUnreachableCode": false,
+    "exactOptionalPropertyTypes": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "isolatedModules": true,
+    "checkJs": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+
+    "types": ["@webgpu/types"]
   }
 }


### PR DESCRIPTION
We need to use our own definition for `AllowSharedBufferSource` (here called `GPUAllowSharedBufferSource`) because the built-in one in TypeScript is broken.

Fixes #178