### PR TITLE
Remove deprecated GPUAdapter isFallbackAdapter

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -2075,13 +2075,6 @@ interface GPUAdapter {
    */
   readonly info: GPUAdapterInfo;
   /**
-   * Returns the value of {@link GPUAdapter#[[adapter]]}.{@link adapter#[[fallback]]}.
-   *
-   * @deprecated Use {@link GPUAdapterInfo#isFallbackAdapter}.
-   * (Note if it's not available, it will be `undefined` which is still falsy.)
-   */
-  readonly isFallbackAdapter?: boolean;
-  /**
    * Requests a device from the adapter.
    * This is a one-time action: if a device is returned successfully,
    * the adapter becomes {@link adapter#[[state]]#"consumed"}.
@@ -2141,10 +2134,8 @@ interface GPUAdapterInfo {
   readonly subgroupMaxSize?: number;
   /**
    * Whether the adapter is a fallback adapter.
-   *
-   * TODO: Temporarily optional until all browsers have implemented it.
    **/
-  readonly isFallbackAdapter?: boolean;
+  readonly isFallbackAdapter: boolean;
 }
 
 declare var GPUAdapterInfo: {


### PR DESCRIPTION
The GPUAdapterInfo isFallbackAdapter attribute has been implemented both in [Chromium](https://issues.chromium.org/issues/409259074) and [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1955057) but not in Safari yet. 

@mwyrzykowski Is that something you can address so that we can move forward with this PR.