### PR TITLE
Add primitive-index GPUFeatureName

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -317,7 +317,8 @@ type GPUFeatureName =
     | "dual-source-blending"
     | "subgroups"
     | "texture-formats-tier1"
-    | "texture-formats-tier2";
+    | "texture-formats-tier2"
+    | "primitive-index";
 type GPUFilterMode =
 
     | "nearest"

--- a/generated/index.d.ts
+++ b/generated/index.d.ts
@@ -317,7 +317,8 @@ type GPUFeatureName =
     | "dual-source-blending"
     | "subgroups"
     | "texture-formats-tier1"
-    | "texture-formats-tier2";
+    | "texture-formats-tier2"
+    | "primitive-index";
 type GPUFilterMode =
 
     | "nearest"


### PR DESCRIPTION
Following up on https://github.com/gpuweb/gpuweb/pull/5273, this PR adds the `"primitive-index"` GPUFeatureName.