### PR TITLE
Add TRANSIENT_ATTACHMENT GPUTextureUsage

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -3420,6 +3420,7 @@ interface GPUTextureUsage {
   readonly TEXTURE_BINDING: GPUFlagsConstant;
   readonly STORAGE_BINDING: GPUFlagsConstant;
   readonly RENDER_ATTACHMENT: GPUFlagsConstant;
+  readonly TRANSIENT_ATTACHMENT: GPUFlagsConstant;
 }
 
 declare var GPUTextureUsage: GPUTextureUsage;

--- a/generated/index.d.ts
+++ b/generated/index.d.ts
@@ -3096,6 +3096,7 @@ interface GPUTextureUsage {
   readonly TEXTURE_BINDING: GPUFlagsConstant;
   readonly STORAGE_BINDING: GPUFlagsConstant;
   readonly RENDER_ATTACHMENT: GPUFlagsConstant;
+  readonly TRANSIENT_ATTACHMENT: GPUFlagsConstant;
 }
 
 declare var GPUTextureUsage: GPUTextureUsage;


### PR DESCRIPTION
This PR adds the `TRANSIENT_ATTACHMENT` GPUTextureUsage added to the spec in https://github.com/gpuweb/gpuweb/pull/5450