### PR TITLE
Fix the use of `generate.mjs` on Windows

### DIFF
--- a/generate.mjs
+++ b/generate.mjs
@@ -86,7 +86,7 @@ ${readFileAsUTF8(srcFilename)}
 }
 
 execute(
-  './node_modules/.bin/bikeshed-to-ts',
+  'bikeshed-to-ts',
   [
     '--in', './gpuweb/spec/index.bs',
     '--out', './generated/index.d.ts',
@@ -95,4 +95,4 @@ execute(
   ]
 );
 fixupGenerated('./generated/index.d.ts', './generated/index.d.ts');
-execute('./node_modules/.bin/prettier', ['-w', 'generated/index.d.ts']);
+execute('prettier', ['-w', 'generated/index.d.ts']);


### PR DESCRIPTION
Replace `bikeshed-to-ts` and `prettier` with bare command names (`bikeshed-to-ts`, `prettier`). The `./ prefix` is not recognized by `cmd.exe`, causing `npm run generate` to fail on Windows. Since `npm run` adds `.bin` to `PATH`, we can directly use bare command names on all platforms.