### PR TITLE
Add "subgroup-size-control" feature

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -319,7 +319,8 @@ type GPUFeatureName =
     | "texture-formats-tier1"
     | "texture-formats-tier2"
     | "primitive-index"
-    | "texture-component-swizzle";
+    | "texture-component-swizzle"
+    | "subgroup-size-control";
 type GPUFilterMode =
 
     | "nearest"

--- a/generated/index.d.ts
+++ b/generated/index.d.ts
@@ -319,7 +319,8 @@ type GPUFeatureName =
     | "texture-formats-tier1"
     | "texture-formats-tier2"
     | "primitive-index"
-    | "texture-component-swizzle";
+    | "texture-component-swizzle"
+    | "subgroup-size-control";
 type GPUFilterMode =
 
     | "nearest"


### PR DESCRIPTION
This patch adds the "subgroup-size-control" feature added to the spec in gpuweb/gpuweb#5578